### PR TITLE
Improvements: keyboard shortcuts, offline workspace init, and more

### DIFF
--- a/docs/INTERACTIVE.md
+++ b/docs/INTERACTIVE.md
@@ -18,6 +18,8 @@ We obtain the frames using the following rules:
 In any case, if a "masks" folder exists in the workspace, we will use that to initialize the mask.
 That way, you can continue annotation from an interrupted run as long as the same workspace is used.
 
+The command line argument `--workspace_init_only` can be used to initialize the workspace and then exit without loading the GUI, allowing the slow importing of images or videos to be performed offline.
+
 There are additional configurations that you can modify in `cutie/config/gui_config.yaml`. You cannot use command line for overriding those. The default should work most of the times.
 
 See [TIPS](../gui/TIPS.md) for some tips on using the tool.

--- a/gui/TIPS.md
+++ b/gui/TIPS.md
@@ -9,6 +9,9 @@ Controls:
 
 - Use left-click for foreground annotation and right-click for background annotation.
 - Use number keys or the spinbox to change the object to be operated on. If it does not respond, most likely the correct number of objects was not specified during program startup.
+- Use left/right arrows to move between frames, shift+arrow to move by 10 frames, and alt/option+arrow to move to the start/end.
+- Use F/space and B to propagate forward and backward, respectively.
+- Use C to commit a frame to permanent memory.
 - Memory can be corrupted by bad segmentations. Make good use of "reset memory" and do not commit bad segmentations.
 - "Export as video" only aggregates visualizations that are saved on disks. You need to check "save overlay" for that to happen.
 

--- a/gui/gui.py
+++ b/gui/gui.py
@@ -320,9 +320,33 @@ class GUI(QWidget):
             QShortcut(QKeySequence(f"Ctrl+{i}"),
                       self).activated.connect(functools.partial(controller.hit_number_key, i))
 
-        # <- and -> shortcuts
+        # next/prev frame shortcuts
         QShortcut(QKeySequence(Qt.Key.Key_Left), self).activated.connect(controller.on_prev_frame)
         QShortcut(QKeySequence(Qt.Key.Key_Right), self).activated.connect(controller.on_next_frame)
+
+        # +/- 10 frames shortcuts
+        QShortcut(QKeySequence(Qt.Key.Key_Left | Qt.KeyboardModifier.ShiftModifier),
+                    self).activated.connect(functools.partial(controller.on_prev_frame, 10))
+        QShortcut(QKeySequence(Qt.Key.Key_Right | Qt.KeyboardModifier.ShiftModifier),
+                    self).activated.connect(functools.partial(controller.on_next_frame, 10))
+        
+        # first/last frame shortcuts
+        QShortcut(QKeySequence(Qt.Key.Key_Left | Qt.KeyboardModifier.AltModifier),
+                    self).activated.connect(functools.partial(controller.on_prev_frame, 999999))
+        QShortcut(QKeySequence(Qt.Key.Key_Right | Qt.KeyboardModifier.AltModifier),
+                    self).activated.connect(functools.partial(controller.on_next_frame, 999999))
+        
+        # commit to permanent memory shortcut
+        QShortcut(QKeySequence(Qt.Key.Key_C), self).activated.connect(controller.on_commit)
+
+        # propagate forward/backward/pause shortcuts
+        QShortcut(QKeySequence(Qt.Key.Key_F), self).activated.connect(controller.on_forward_propagation)
+        QShortcut(QKeySequence(Qt.Key.Key_Space), self).activated.connect(controller.on_forward_propagation)
+        QShortcut(QKeySequence(Qt.Key.Key_B), self).activated.connect(controller.on_backward_propagation)
+
+        # quit shortcut
+        QShortcut(QKeySequence(Qt.Key.Key_Q), self).activated.connect(self.close)
+
 
     def resizeEvent(self, event):
         self.controller.show_current_frame()

--- a/gui/gui.py
+++ b/gui/gui.py
@@ -1,4 +1,5 @@
 import functools
+from pathlib import Path
 
 import numpy as np
 from omegaconf import DictConfig
@@ -194,7 +195,7 @@ class GUI(QWidget):
         self.tips.setReadOnly(True)
         self.tips.setTextInteractionFlags(Qt.NoTextInteraction)
         self.tips.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-        with open('./gui/TIPS.md') as f:
+        with open(Path(__file__).parent / 'TIPS.md', 'r') as f:
             self.tips.setMarkdown(f.read())
 
         # navigator

--- a/gui/main_controller.py
+++ b/gui/main_controller.py
@@ -452,12 +452,12 @@ class MainController():
         if self.interaction is not None:
             self.interaction = None
 
-    def on_prev_frame(self):
-        new_ti = max(0, self.curr_ti - 1)
+    def on_prev_frame(self, step=1):
+        new_ti = max(0, self.curr_ti - step)
         self.gui.tl_slider.setValue(new_ti)
 
-    def on_next_frame(self):
-        new_ti = min(self.curr_ti + 1, self.length - 1)
+    def on_next_frame(self, step=1):
+        new_ti = min(self.curr_ti + step, self.length - 1)
         self.gui.tl_slider.setValue(new_ti)
 
     def update_gpu_gauges(self):

--- a/gui/main_controller.py
+++ b/gui/main_controller.py
@@ -61,6 +61,8 @@ class MainController():
 
         # main components
         self.res_man = ResourceManager(cfg)
+        if 'workspace_init_only' in cfg and cfg['workspace_init_only']:
+            return
         self.processor = InferenceCore(self.cutie, self.cfg)
         self.gui = GUI(self, self.cfg)
 

--- a/interactive_demo.py
+++ b/interactive_demo.py
@@ -27,6 +27,8 @@ def get_arguments():
                         help='directory for storing buffered images (if needed) and output masks',
                         default=None)
     parser.add_argument('--num_objects', type=int, default=1)
+    parser.add_argument('--workspace_init_only', action='store_true',
+                        help='initialize the workspace and exit')
 
     args = parser.parse_args()
     return args
@@ -73,4 +75,7 @@ if __name__ in "__main__":
     app = QApplication(sys.argv)
     qdarktheme.setup_theme("auto")
     ex = MainController(cfg)
-    sys.exit(app.exec())
+    if 'workspace_init_only' in cfg and cfg['workspace_init_only']:
+        sys.exit(0)
+    else:
+        sys.exit(app.exec())

--- a/interactive_demo.py
+++ b/interactive_demo.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 # fix for Windows
@@ -9,16 +10,6 @@ import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 from argparse import ArgumentParser
-
-import torch
-from omegaconf import open_dict
-from hydra import compose, initialize
-import logging
-from PySide6.QtWidgets import QApplication
-import qdarktheme
-
-from gui.main_controller import MainController
-
 
 def get_arguments():
     parser = ArgumentParser()
@@ -42,14 +33,23 @@ def get_arguments():
 
 
 if __name__ in "__main__":
+    # input arguments
+    args = get_arguments()
+
+    # perform slow imports after parsing args
+    import torch
+    from omegaconf import open_dict
+    from hydra import compose, initialize
+    from PySide6.QtWidgets import QApplication
+    import qdarktheme
+    from gui.main_controller import MainController
+
+    # logging
     log = logging.getLogger()
 
     # getting hydra's config without using its decorator
     initialize(version_base='1.3.2', config_path="cutie/config", job_name="gui")
     cfg = compose(config_name="gui_config")
-
-    # input arguments
-    args = get_arguments()
 
     # general setup
     torch.set_grad_enabled(False)


### PR DESCRIPTION
Hi all, thanks for this wonderful tool. Here are some changes that I made while using it for an annotation project:
- Added keyboard shortcuts to the GUI for moving forward/backward by 10 frames (shift+arrow) and to the start/end (option/alt+arrow)
- Added keyboard shortcuts for committing a frame to permanent memory (C), propagating forward (F/space) and backward (B), and quitting the GUI
- Added command line flag `--workspace_init_only` to initialize the workspace (including importing images or video) and then exit without creating GUI
- Documented these in `TIPS.md` and `INTERACTIVE.md`

Finally, a couple minor fixes/edits:
- Changed GUI to look for `TIPS.md` in the appropriate source path, instead of relative to `pwd` (without this, the GUI will crash if not launched from the root directory of the repo)
- Moved some imports and hydra initialization to after parsing command line args to make `--help` print faster

Let me know if you need anything from me to help with merging these changes. Thanks!