### PR TITLE
Option to enable offline processing

### DIFF
--- a/cutie/model/big_modules.py
+++ b/cutie/model/big_modules.py
@@ -23,11 +23,12 @@ class PixelEncoder(nn.Module):
         super().__init__()
 
         self.is_resnet = 'resnet' in model_cfg.pixel_encoder.type
+        resnet_model_path = model_cfg.get('resnet_model_path')
         if self.is_resnet:
             if model_cfg.pixel_encoder.type == 'resnet18':
-                network = resnet.resnet18(pretrained=True)
+                network = resnet.resnet18(pretrained=True, model_dir=resnet_model_path)
             elif model_cfg.pixel_encoder.type == 'resnet50':
-                network = resnet.resnet50(pretrained=True)
+                network = resnet.resnet50(pretrained=True, model_dir=resnet_model_path)
             else:
                 raise NotImplementedError
             self.conv1 = network.conv1
@@ -97,10 +98,11 @@ class MaskEncoder(nn.Module):
         self.single_object = single_object
         extra_dim = 1 if single_object else 2
 
+        resnet_model_path = model_cfg.get('resnet_model_path')
         if model_cfg.mask_encoder.type == 'resnet18':
-            network = resnet.resnet18(pretrained=True, extra_dim=extra_dim)
+            network = resnet.resnet18(pretrained=True, extra_dim=extra_dim, model_dir=resnet_model_path)
         elif model_cfg.mask_encoder.type == 'resnet50':
-            network = resnet.resnet50(pretrained=True, extra_dim=extra_dim)
+            network = resnet.resnet50(pretrained=True, extra_dim=extra_dim, model_dir=resnet_model_path)
         else:
             raise NotImplementedError
         self.conv1 = network.conv1

--- a/cutie/model/utils/resnet.py
+++ b/cutie/model/utils/resnet.py
@@ -165,15 +165,15 @@ class ResNet(nn.Module):
         return nn.Sequential(*layers)
 
 
-def resnet18(pretrained=True, extra_dim=0):
+def resnet18(pretrained=True, extra_dim=0, model_dir=None):
     model = ResNet(BasicBlock, [2, 2, 2, 2], extra_dim)
     if pretrained:
-        load_weights_add_extra_dim(model, model_zoo.load_url(model_urls['resnet18']), extra_dim)
+        load_weights_add_extra_dim(model, model_zoo.load_url(model_urls['resnet18'], model_dir=model_dir), extra_dim)
     return model
 
 
-def resnet50(pretrained=True, extra_dim=0):
+def resnet50(pretrained=True, extra_dim=0, model_dir=None):
     model = ResNet(Bottleneck, [3, 4, 6, 3], extra_dim)
     if pretrained:
-        load_weights_add_extra_dim(model, model_zoo.load_url(model_urls['resnet50']), extra_dim)
+        load_weights_add_extra_dim(model, model_zoo.load_url(model_urls['resnet50'], model_dir=model_dir), extra_dim)
     return model


### PR DESCRIPTION
Right now the Cutie framework uses the ResNet model for its PixelEncoder and MaskEncoder.
The ResNet model weights are downloaded by the torch framework on demand to the users local torch cache.
This requires the user to be online at first time use else the processing will fail.

In cases using the Cutie framework where the user cannot be online this is an obstacle.

Therefore suggesting to add an option to the model configuration called 'resnet_model_path' and update to use this ResNet model path to the PixelEncoder and MaskEncoder, which forward down to the actual torch  model_zoo.load_url call.

The suggested code changes will only take effect if the model configuration is actually added this new 'resnet_model_path'. If not present in model configuration, the ResNet models are downloaded as previously. So changes will not change any existing use.

If as user then like to use the Cutie framework offline, an andvance download of the ResNet model to a location of choice and a modification to the used model configuration is now possible.