### PR TITLE
fix: convert_frames_to_video uses `.png` as images and exports video with green overlay 

### DIFF
--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -165,13 +165,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cutie-onnx-weights
-          path: .
+          path: weights
 
       - name: Download SAM weights
         uses: actions/download-artifact@v4
         with:
           name: sam-onnx-weights
-          path: .
+          path: weights
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -255,13 +255,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cutie-onnx-weights
-          path: .
+          path: weights
 
       - name: Download SAM weights
         uses: actions/download-artifact@v4
         with:
           name: sam-onnx-weights
-          path: .
+          path: weights
 
       - name: Build in Arch Linux container
         run: |
@@ -279,7 +279,11 @@ jobs:
                 python \
                 python-pip \
                 python-virtualenv
-              python -m venv venv
+              python -m pip install --upgrade pip
+              python -m pip install uv
+              uv python install 3.10
+              uv venv --python 3.10 venv
+              ./venv/bin/python --version
               ./venv/bin/python -m pip install --upgrade pip
               ./venv/bin/pip install -e .
               ./venv/bin/pip install torch torchvision onnx onnxruntime onnxscript nuitka

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -423,6 +423,7 @@ jobs:
               pacman -S --noconfirm \
                 base-devel \
                 git \
+                libxcb \
                 patchelf \
                 python \
                 python-pip \
@@ -473,6 +474,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-native
+    if: ${{ always() && needs.build-native.result == 'success' }}
 
     steps:
       - name: Download ubuntu archive
@@ -509,7 +511,7 @@ jobs:
     needs:
       - build-arch
       - publish-native-release
-    if: needs.build-arch.result == 'success'
+    if: ${{ always() && needs.build-arch.result == 'success' && needs.publish-native-release.result == 'success' }}
 
     steps:
       - name: Download archlinux archive

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -22,12 +22,61 @@ permissions:
 env:
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: "1"
+  CUTIE_BASE_URL: https://github.com/hkchengrex/Cutie/releases/download/v1.0/cutie-base-mega.pth
+  RITM_URL: https://github.com/hkchengrex/Cutie/releases/download/v1.0/coco_lvis_h18_itermask.pth
   SAM2_SMALL_CHECKPOINT: sam2.1_hiera_small.pt
   SAM2_SMALL_URL: https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_small.pt
 
 jobs:
-  export-weights:
-    name: Export shared ONNX weights
+  export-sam-weights:
+    name: Export SAM ONNX weights
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install samexporter git+https://github.com/facebookresearch/segment-anything-2.git
+
+      - name: Download SAM2 checkpoint
+        run: |
+          mkdir -p weights
+          curl -L "$SAM2_SMALL_URL" -o "weights/$SAM2_SMALL_CHECKPOINT"
+
+      - name: Export SAM2 ONNX models
+        run: |
+          python -m samexporter.export_sam2 \
+            --checkpoint "weights/$SAM2_SMALL_CHECKPOINT" \
+            --output_encoder weights/sam2.1_hiera_small.encoder.onnx \
+            --output_decoder weights/sam2.1_hiera_small.decoder.onnx \
+            --model_type sam2.1_hiera_small
+
+      - name: Upload SAM weights artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sam-onnx-weights
+          path: |
+            weights/sam2.1_hiera_small.encoder.onnx
+            weights/sam2.1_hiera_small.decoder.onnx
+          if-no-files-found: error
+
+  export-cutie-weights:
+    name: Export Cutie ONNX weights
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -50,15 +99,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install samexporter git+https://github.com/facebookresearch/segment-anything-2.git
+          pip install torch torchvision onnx onnxruntime onnxscript
 
-      - name: Download pretrained weights
+      - name: Download Cutie checkpoints
         run: |
-          python cutie/utils/download_models.py
           mkdir -p weights
-          curl -L "$SAM2_SMALL_URL" -o "weights/$SAM2_SMALL_CHECKPOINT"
+          curl -L "$CUTIE_BASE_URL" -o weights/cutie-base-mega.pth
+          curl -L "$RITM_URL" -o weights/coco_lvis_h18_itermask.pth
 
-      - name: Export ONNX models
+      - name: Export Cutie ONNX models
         run: |
           python -m scripts.export_onnx \
             --output weights/cutie_image_encoder.onnx \
@@ -80,16 +129,11 @@ jobs:
             --height 480 \
             --width 864 \
             --opset 18
-          python -m samexporter.export_sam2 \
-            --checkpoint "weights/$SAM2_SMALL_CHECKPOINT" \
-            --output_encoder weights/sam2.1_hiera_small.encoder.onnx \
-            --output_decoder weights/sam2.1_hiera_small.decoder.onnx \
-            --model_type sam2.1_hiera_small
 
-      - name: Upload weights artifact
+      - name: Upload Cutie weights artifact
         uses: actions/upload-artifact@v4
         with:
-          name: onnx-weights
+          name: cutie-onnx-weights
           path: weights
           if-no-files-found: error
   build-native:
@@ -97,7 +141,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     needs:
-      - export-weights
+      - export-sam-weights
+      - export-cutie-weights
     strategy:
       fail-fast: false
       matrix:
@@ -116,10 +161,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Download exported weights
+      - name: Download Cutie weights
         uses: actions/download-artifact@v4
         with:
-          name: onnx-weights
+          name: cutie-onnx-weights
+          path: .
+
+      - name: Download SAM weights
+        uses: actions/download-artifact@v4
+        with:
+          name: sam-onnx-weights
           path: .
 
       - name: Set up Python
@@ -193,16 +244,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs:
-      - export-weights
+      - export-sam-weights
+      - export-cutie-weights
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Download exported weights
+      - name: Download Cutie weights
         uses: actions/download-artifact@v4
         with:
-          name: onnx-weights
+          name: cutie-onnx-weights
+          path: .
+
+      - name: Download SAM weights
+        uses: actions/download-artifact@v4
+        with:
+          name: sam-onnx-weights
           path: .
 
       - name: Build in Arch Linux container

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -431,7 +431,7 @@ jobs:
               ./uv-bootstrap/bin/python -m pip install --upgrade pip
               ./uv-bootstrap/bin/pip install uv
               ./uv-bootstrap/bin/uv python install 3.10
-              ./uv-bootstrap/bin/uv venv --python 3.10 venv
+              ./uv-bootstrap/bin/uv venv --python 3.10 --seed venv
               ./venv/bin/python --version
               ./venv/bin/python -m pip install --upgrade pip
               ./venv/bin/pip install -e .

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -1,0 +1,93 @@
+name: Export Nuitka ONNX Bundle
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-nuitka-onnx:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            patchelf
+
+      - name: Create virtual environment
+        run: python -m venv venv
+
+      - name: Install Python dependencies
+        run: |
+          ./venv/bin/python -m pip install --upgrade pip
+          ./venv/bin/pip install -e .
+          ./venv/bin/pip install \
+            torch \
+            torchvision \
+            onnx \
+            onnxruntime \
+            onnxscript \
+            nuitka
+
+      - name: Download pretrained weights
+        run: ./venv/bin/python cutie/utils/download_models.py
+
+      - name: Export ONNX models
+        run: |
+          ./venv/bin/python -m scripts.export_onnx \
+            --output weights/cutie_image_encoder.onnx \
+            --weights weights/cutie-base-mega.pth \
+            --height 480 \
+            --width 864 \
+            --opset 18
+          ./venv/bin/python -m scripts.export_onnx_pipeline \
+            --weights weights/cutie-base-mega.pth \
+            --output-dir weights \
+            --use-dynamo \
+            --height 480 \
+            --width 864 \
+            --num-objects 1 \
+            --memory-frames 1
+          ./venv/bin/python -m scripts.export_ritm_onnx \
+            --weights weights/coco_lvis_h18_itermask.pth \
+            --output weights/ritm_no_brs.onnx \
+            --height 480 \
+            --width 864 \
+            --opset 18
+
+      - name: Build Nuitka standalone bundle
+        run: |
+          ORT_CAPI=$(./venv/bin/python -c "import onnxruntime, pathlib; print(pathlib.Path(onnxruntime.__file__).resolve().parent / 'capi')")
+
+          ./venv/bin/python -m nuitka interactive_demo_onnx.py \
+            --standalone \
+            --assume-yes-for-downloads \
+            --remove-output \
+            --enable-plugin=pyside6 \
+            --include-qt-plugins=platforminputcontexts \
+            --noinclude-qt-translations \
+            --nofollow-import-to=torch,torchvision,gui.main_controller,gui.click_controller,gui.interaction,gui.interactive_utils,gui.reader,gui.ritm,cutie.model,cutie.inference \
+            --include-data-dir=cutie/config=cutie/config \
+            --include-data-dir=weights=weights \
+            --include-data-files=gui/TIPS.md=gui/TIPS.md \
+            --include-data-dir="$ORT_CAPI"=onnxruntime/capi \
+            --output-dir=build_nuitka_onnx \
+            --output-filename=cutie_onnx
+
+      - name: Upload Nuitka bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: cutie-onnx-nuitka-bundle
+          path: build_nuitka_onnx
+          if-no-files-found: error

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -6,6 +6,15 @@ on:
       tag:
         description: Git tag to create or update for this release
         required: true
+      refresh_weights:
+        description: Re-export ONNX weights instead of downloading cached ones
+        required: false
+        type: boolean
+        default: false
+      weights_tag:
+        description: Git tag that stores cached ONNX weight assets
+        required: false
+        default: onnx-weights-cache
       release_name:
         description: Release title
         required: false
@@ -30,6 +39,7 @@ env:
 jobs:
   export-sam-weights:
     name: Export SAM ONNX weights
+    if: ${{ inputs.refresh_weights }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -77,6 +87,7 @@ jobs:
 
   export-cutie-weights:
     name: Export Cutie ONNX weights
+    if: ${{ inputs.refresh_weights }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -136,13 +147,135 @@ jobs:
           name: cutie-onnx-weights
           path: weights
           if-no-files-found: error
+
+  download-sam-weights:
+    name: Download cached SAM ONNX weights
+    if: ${{ !inputs.refresh_weights }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Download cached SAM weights release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p cached-sam
+          gh release download "${{ inputs.weights_tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern sam-onnx-weights.zip \
+            --dir cached-sam
+
+      - name: Extract cached SAM weights
+        run: |
+          mkdir -p weights
+          unzip -o cached-sam/sam-onnx-weights.zip -d weights
+
+      - name: Upload SAM weights artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sam-onnx-weights
+          path: |
+            weights/sam2.1_hiera_small.encoder.onnx
+            weights/sam2.1_hiera_small.decoder.onnx
+          if-no-files-found: error
+
+  download-cutie-weights:
+    name: Download cached Cutie ONNX weights
+    if: ${{ !inputs.refresh_weights }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Download cached Cutie weights release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p cached-cutie
+          gh release download "${{ inputs.weights_tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern cutie-onnx-weights.zip \
+            --dir cached-cutie
+
+      - name: Extract cached Cutie weights
+        run: |
+          mkdir -p weights
+          unzip -o cached-cutie/cutie-onnx-weights.zip -d weights
+
+      - name: Upload Cutie weights artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cutie-onnx-weights
+          path: weights
+          if-no-files-found: error
+
+  publish-weights-cache:
+    name: Publish cached ONNX weights
+    if: ${{ inputs.refresh_weights }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - export-sam-weights
+      - export-cutie-weights
+
+    steps:
+      - name: Download Cutie weights artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cutie-onnx-weights
+          path: weights
+
+      - name: Download SAM weights artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sam-onnx-weights
+          path: weights
+
+      - name: Create weight archives
+        run: |
+          mkdir -p release-assets
+          cd weights
+          zip -r ../release-assets/cutie-onnx-weights.zip \
+            cutie-base-mega.pth \
+            coco_lvis_h18_itermask.pth \
+            cutie_image_encoder.onnx \
+            cutie_memory_write.onnx \
+            cutie_read_decode.onnx \
+            ritm_no_brs.onnx
+          zip -r ../release-assets/sam-onnx-weights.zip \
+            sam2.1_hiera_small.encoder.onnx \
+            sam2.1_hiera_small.decoder.onnx
+
+      - name: Publish cached weight assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.weights_tag }}
+          target_commitish: ${{ github.sha }}
+          name: ONNX Weights Cache
+          prerelease: true
+          files: release-assets/*.zip
+          generate_release_notes: false
   build-native:
     name: Build ${{ matrix.label }}
+    if: >-
+      ${{
+        always() &&
+        !contains(needs.*.result, 'failure') &&
+        (
+          needs.export-sam-weights.result == 'success' ||
+          needs.download-sam-weights.result == 'success'
+        ) &&
+        (
+          needs.export-cutie-weights.result == 'success' ||
+          needs.download-cutie-weights.result == 'success'
+        )
+      }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     needs:
       - export-sam-weights
       - export-cutie-weights
+      - download-sam-weights
+      - download-cutie-weights
     strategy:
       fail-fast: false
       matrix:
@@ -241,11 +374,26 @@ jobs:
 
   build-arch:
     name: Build archlinux
+    if: >-
+      ${{
+        always() &&
+        !contains(needs.*.result, 'failure') &&
+        (
+          needs.export-sam-weights.result == 'success' ||
+          needs.download-sam-weights.result == 'success'
+        ) &&
+        (
+          needs.export-cutie-weights.result == 'success' ||
+          needs.download-cutie-weights.result == 'success'
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs:
       - export-sam-weights
       - export-cutie-weights
+      - download-sam-weights
+      - download-cutie-weights
 
     steps:
       - name: Check out repository
@@ -279,10 +427,11 @@ jobs:
                 python \
                 python-pip \
                 python-virtualenv
-              python -m pip install --upgrade pip
-              python -m pip install uv
-              uv python install 3.10
-              uv venv --python 3.10 venv
+              python -m venv uv-bootstrap
+              ./uv-bootstrap/bin/python -m pip install --upgrade pip
+              ./uv-bootstrap/bin/pip install uv
+              ./uv-bootstrap/bin/uv python install 3.10
+              ./uv-bootstrap/bin/uv venv --python 3.10 venv
               ./venv/bin/python --version
               ./venv/bin/python -m pip install --upgrade pip
               ./venv/bin/pip install -e .

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: write
 
+env:
+  PYTHONIOENCODING: utf-8
+  PYTHONUTF8: "1"
+
 jobs:
   build-native:
     name: Build ${{ matrix.label }}

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -219,20 +219,30 @@ jobs:
           path: cutie-onnx-nuitka-archlinux.zip
           if-no-files-found: error
 
-  publish-release:
-    name: Publish release
+  publish-native-release:
+    name: Publish native release assets
     runs-on: ubuntu-latest
     needs:
       - build-native
-      - build-arch
 
     steps:
-      - name: Download release archives
+      - name: Download ubuntu archive
         uses: actions/download-artifact@v4
         with:
           path: release-assets
-          pattern: cutie-onnx-nuitka-*.zip
-          merge-multiple: true
+          name: cutie-onnx-nuitka-ubuntu.zip
+
+      - name: Download windows archive
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          name: cutie-onnx-nuitka-windows.zip
+
+      - name: Download macos archive
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          name: cutie-onnx-nuitka-macos.zip
 
       - name: Create or update GitHub release
         uses: softprops/action-gh-release@v2
@@ -243,3 +253,27 @@ jobs:
           prerelease: ${{ inputs.prerelease }}
           files: release-assets/*.zip
           generate_release_notes: true
+
+  publish-arch-release:
+    name: Publish archlinux release asset
+    runs-on: ubuntu-latest
+    needs:
+      - build-arch
+      - publish-native-release
+    if: needs.build-arch.result == 'success'
+
+    steps:
+      - name: Download archlinux archive
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          name: cutie-onnx-nuitka-archlinux.zip
+
+      - name: Append archlinux asset to GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          target_commitish: ${{ github.sha }}
+          name: ${{ inputs.release_name }}
+          prerelease: ${{ inputs.prerelease }}
+          files: release-assets/cutie-onnx-nuitka-archlinux.zip

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -2,11 +2,41 @@ name: Export Nuitka ONNX Bundle
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Git tag to create or update for this release
+        required: true
+      release_name:
+        description: Release title
+        required: false
+        default: Cutie ONNX Nuitka Bundle
+      prerelease:
+        description: Mark the GitHub release as a prerelease
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
 
 jobs:
-  build-nuitka-onnx:
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
+  build-native:
+    name: Build ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ubuntu
+            runner: ubuntu-latest
+            archive_name: cutie-onnx-nuitka-ubuntu.zip
+          - label: windows
+            runner: windows-latest
+            archive_name: cutie-onnx-nuitka-windows.zip
+          - label: macos
+            runner: macos-latest
+            archive_name: cutie-onnx-nuitka-macos.zip
 
     steps:
       - name: Check out repository
@@ -19,75 +49,197 @@ jobs:
           cache: pip
 
       - name: Install system dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            patchelf
+          sudo apt-get install -y build-essential patchelf
 
       - name: Create virtual environment
-        run: python -m venv venv
+        shell: pwsh
+        run: |
+          python -m venv venv
+          if ($env:RUNNER_OS -eq "Windows") {
+            "PYTHON_BIN=$pwd/venv/Scripts/python.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "PIP_BIN=$pwd/venv/Scripts/pip.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          } else {
+            "PYTHON_BIN=$pwd/venv/bin/python" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "PIP_BIN=$pwd/venv/bin/pip" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
 
       - name: Install Python dependencies
+        shell: pwsh
         run: |
-          ./venv/bin/python -m pip install --upgrade pip
-          ./venv/bin/pip install -e .
-          ./venv/bin/pip install \
-            torch \
-            torchvision \
-            onnx \
-            onnxruntime \
-            onnxscript \
-            nuitka
+          & $env:PYTHON_BIN -m pip install --upgrade pip
+          & $env:PIP_BIN install -e .
+          & $env:PIP_BIN install torch torchvision onnx onnxruntime onnxscript nuitka
 
       - name: Download pretrained weights
-        run: ./venv/bin/python cutie/utils/download_models.py
+        shell: pwsh
+        run: |
+          & $env:PYTHON_BIN cutie/utils/download_models.py
 
       - name: Export ONNX models
+        shell: pwsh
         run: |
-          ./venv/bin/python -m scripts.export_onnx \
-            --output weights/cutie_image_encoder.onnx \
-            --weights weights/cutie-base-mega.pth \
-            --height 480 \
-            --width 864 \
+          & $env:PYTHON_BIN -m scripts.export_onnx `
+            --output weights/cutie_image_encoder.onnx `
+            --weights weights/cutie-base-mega.pth `
+            --height 480 `
+            --width 864 `
             --opset 18
-          ./venv/bin/python -m scripts.export_onnx_pipeline \
-            --weights weights/cutie-base-mega.pth \
-            --output-dir weights \
-            --use-dynamo \
-            --height 480 \
-            --width 864 \
-            --num-objects 1 \
+          & $env:PYTHON_BIN -m scripts.export_onnx_pipeline `
+            --weights weights/cutie-base-mega.pth `
+            --output-dir weights `
+            --use-dynamo `
+            --height 480 `
+            --width 864 `
+            --num-objects 1 `
             --memory-frames 1
-          ./venv/bin/python -m scripts.export_ritm_onnx \
-            --weights weights/coco_lvis_h18_itermask.pth \
-            --output weights/ritm_no_brs.onnx \
-            --height 480 \
-            --width 864 \
+          & $env:PYTHON_BIN -m scripts.export_ritm_onnx `
+            --weights weights/coco_lvis_h18_itermask.pth `
+            --output weights/ritm_no_brs.onnx `
+            --height 480 `
+            --width 864 `
             --opset 18
 
       - name: Build Nuitka standalone bundle
+        shell: pwsh
         run: |
-          ORT_CAPI=$(./venv/bin/python -c "import onnxruntime, pathlib; print(pathlib.Path(onnxruntime.__file__).resolve().parent / 'capi')")
+          $ortCapi = & $env:PYTHON_BIN -c "import onnxruntime, pathlib; print(pathlib.Path(onnxruntime.__file__).resolve().parent / 'capi')"
 
-          ./venv/bin/python -m nuitka interactive_demo_onnx.py \
-            --standalone \
-            --assume-yes-for-downloads \
-            --remove-output \
-            --enable-plugin=pyside6 \
-            --include-qt-plugins=platforminputcontexts \
-            --noinclude-qt-translations \
-            --nofollow-import-to=torch,torchvision,gui.main_controller,gui.click_controller,gui.interaction,gui.interactive_utils,gui.reader,gui.ritm,cutie.model,cutie.inference \
-            --include-data-dir=cutie/config=cutie/config \
-            --include-data-dir=weights=weights \
-            --include-data-files=gui/TIPS.md=gui/TIPS.md \
-            --include-data-dir="$ORT_CAPI"=onnxruntime/capi \
-            --output-dir=build_nuitka_onnx \
+          & $env:PYTHON_BIN -m nuitka interactive_demo_onnx.py `
+            --standalone `
+            --assume-yes-for-downloads `
+            --remove-output `
+            --enable-plugin=pyside6 `
+            --include-qt-plugins=platforminputcontexts `
+            --noinclude-qt-translations `
+            --nofollow-import-to=torch,torchvision,gui.main_controller,gui.click_controller,gui.interaction,gui.interactive_utils,gui.reader,gui.ritm,cutie.model,cutie.inference `
+            --include-data-dir=cutie/config=cutie/config `
+            --include-data-dir=weights=weights `
+            --include-data-files=gui/TIPS.md=gui/TIPS.md `
+            --include-data-dir="$ortCapi"=onnxruntime/capi `
+            --output-dir=build_nuitka_onnx `
             --output-filename=cutie_onnx
 
-      - name: Upload Nuitka bundle
+      - name: Create release archive
+        shell: pwsh
+        run: |
+          if (Test-Path "${{ matrix.archive_name }}") {
+            Remove-Item "${{ matrix.archive_name }}" -Force
+          }
+          Compress-Archive -Path build_nuitka_onnx -DestinationPath "${{ matrix.archive_name }}"
+
+      - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cutie-onnx-nuitka-bundle
-          path: build_nuitka_onnx
+          name: ${{ matrix.archive_name }}
+          path: ${{ matrix.archive_name }}
           if-no-files-found: error
+
+  build-arch:
+    name: Build archlinux
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build in Arch Linux container
+        run: |
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            archlinux:latest \
+            bash -lc '
+              set -euxo pipefail
+              pacman -Syu --noconfirm
+              pacman -S --noconfirm \
+                base-devel \
+                git \
+                patchelf \
+                python \
+                python-pip \
+                python-virtualenv
+              python -m venv venv
+              ./venv/bin/python -m pip install --upgrade pip
+              ./venv/bin/pip install -e .
+              ./venv/bin/pip install torch torchvision onnx onnxruntime onnxscript nuitka
+              ./venv/bin/python cutie/utils/download_models.py
+              ./venv/bin/python -m scripts.export_onnx \
+                --output weights/cutie_image_encoder.onnx \
+                --weights weights/cutie-base-mega.pth \
+                --height 480 \
+                --width 864 \
+                --opset 18
+              ./venv/bin/python -m scripts.export_onnx_pipeline \
+                --weights weights/cutie-base-mega.pth \
+                --output-dir weights \
+                --use-dynamo \
+                --height 480 \
+                --width 864 \
+                --num-objects 1 \
+                --memory-frames 1
+              ./venv/bin/python -m scripts.export_ritm_onnx \
+                --weights weights/coco_lvis_h18_itermask.pth \
+                --output weights/ritm_no_brs.onnx \
+                --height 480 \
+                --width 864 \
+                --opset 18
+              ORT_CAPI=$(./venv/bin/python -c "import onnxruntime, pathlib; print(pathlib.Path(onnxruntime.__file__).resolve().parent / \"capi\")")
+              ./venv/bin/python -m nuitka interactive_demo_onnx.py \
+                --standalone \
+                --assume-yes-for-downloads \
+                --remove-output \
+                --enable-plugin=pyside6 \
+                --include-qt-plugins=platforminputcontexts \
+                --noinclude-qt-translations \
+                --nofollow-import-to=torch,torchvision,gui.main_controller,gui.click_controller,gui.interaction,gui.interactive_utils,gui.reader,gui.ritm,cutie.model,cutie.inference \
+                --include-data-dir=cutie/config=cutie/config \
+                --include-data-dir=weights=weights \
+                --include-data-files=gui/TIPS.md=gui/TIPS.md \
+                --include-data-dir="$ORT_CAPI"=onnxruntime/capi \
+                --output-dir=build_nuitka_onnx \
+                --output-filename=cutie_onnx
+            '
+
+      - name: Create release archive
+        shell: pwsh
+        run: |
+          if (Test-Path cutie-onnx-nuitka-archlinux.zip) {
+            Remove-Item cutie-onnx-nuitka-archlinux.zip -Force
+          }
+          Compress-Archive -Path build_nuitka_onnx -DestinationPath cutie-onnx-nuitka-archlinux.zip
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cutie-onnx-nuitka-archlinux.zip
+          path: cutie-onnx-nuitka-archlinux.zip
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs:
+      - build-native
+      - build-arch
+
+    steps:
+      - name: Download release archives
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          pattern: cutie-onnx-nuitka-*.zip
+          merge-multiple: true
+
+      - name: Create or update GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          target_commitish: ${{ github.sha }}
+          name: ${{ inputs.release_name }}
+          prerelease: ${{ inputs.prerelease }}
+          files: release-assets/*.zip
+          generate_release_notes: true

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
           cache: pip
 
       - name: Install system dependencies

--- a/.github/workflows/export-nuitka-onnx.yml
+++ b/.github/workflows/export-nuitka-onnx.yml
@@ -22,12 +22,82 @@ permissions:
 env:
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: "1"
+  SAM2_SMALL_CHECKPOINT: sam2.1_hiera_small.pt
+  SAM2_SMALL_URL: https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_small.pt
 
 jobs:
+  export-weights:
+    name: Export shared ONNX weights
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install samexporter git+https://github.com/facebookresearch/segment-anything-2.git
+
+      - name: Download pretrained weights
+        run: |
+          python cutie/utils/download_models.py
+          mkdir -p weights
+          curl -L "$SAM2_SMALL_URL" -o "weights/$SAM2_SMALL_CHECKPOINT"
+
+      - name: Export ONNX models
+        run: |
+          python -m scripts.export_onnx \
+            --output weights/cutie_image_encoder.onnx \
+            --weights weights/cutie-base-mega.pth \
+            --height 480 \
+            --width 864 \
+            --opset 18
+          python -m scripts.export_onnx_pipeline \
+            --weights weights/cutie-base-mega.pth \
+            --output-dir weights \
+            --use-dynamo \
+            --height 480 \
+            --width 864 \
+            --num-objects 1 \
+            --memory-frames 1
+          python -m scripts.export_ritm_onnx \
+            --weights weights/coco_lvis_h18_itermask.pth \
+            --output weights/ritm_no_brs.onnx \
+            --height 480 \
+            --width 864 \
+            --opset 18
+          python -m samexporter.export_sam2 \
+            --checkpoint "weights/$SAM2_SMALL_CHECKPOINT" \
+            --output_encoder weights/sam2.1_hiera_small.encoder.onnx \
+            --output_decoder weights/sam2.1_hiera_small.decoder.onnx \
+            --model_type sam2.1_hiera_small
+
+      - name: Upload weights artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: onnx-weights
+          path: weights
+          if-no-files-found: error
   build-native:
     name: Build ${{ matrix.label }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
+    needs:
+      - export-weights
     strategy:
       fail-fast: false
       matrix:
@@ -45,6 +115,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Download exported weights
+        uses: actions/download-artifact@v4
+        with:
+          name: onnx-weights
+          path: .
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -76,35 +152,6 @@ jobs:
           & $env:PYTHON_BIN -m pip install --upgrade pip
           & $env:PIP_BIN install -e .
           & $env:PIP_BIN install torch torchvision onnx onnxruntime onnxscript nuitka
-
-      - name: Download pretrained weights
-        shell: pwsh
-        run: |
-          & $env:PYTHON_BIN cutie/utils/download_models.py
-
-      - name: Export ONNX models
-        shell: pwsh
-        run: |
-          & $env:PYTHON_BIN -m scripts.export_onnx `
-            --output weights/cutie_image_encoder.onnx `
-            --weights weights/cutie-base-mega.pth `
-            --height 480 `
-            --width 864 `
-            --opset 18
-          & $env:PYTHON_BIN -m scripts.export_onnx_pipeline `
-            --weights weights/cutie-base-mega.pth `
-            --output-dir weights `
-            --use-dynamo `
-            --height 480 `
-            --width 864 `
-            --num-objects 1 `
-            --memory-frames 1
-          & $env:PYTHON_BIN -m scripts.export_ritm_onnx `
-            --weights weights/coco_lvis_h18_itermask.pth `
-            --output weights/ritm_no_brs.onnx `
-            --height 480 `
-            --width 864 `
-            --opset 18
 
       - name: Build Nuitka standalone bundle
         shell: pwsh
@@ -145,10 +192,18 @@ jobs:
     name: Build archlinux
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    needs:
+      - export-weights
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Download exported weights
+        uses: actions/download-artifact@v4
+        with:
+          name: onnx-weights
+          path: .
 
       - name: Build in Arch Linux container
         run: |
@@ -170,27 +225,6 @@ jobs:
               ./venv/bin/python -m pip install --upgrade pip
               ./venv/bin/pip install -e .
               ./venv/bin/pip install torch torchvision onnx onnxruntime onnxscript nuitka
-              ./venv/bin/python cutie/utils/download_models.py
-              ./venv/bin/python -m scripts.export_onnx \
-                --output weights/cutie_image_encoder.onnx \
-                --weights weights/cutie-base-mega.pth \
-                --height 480 \
-                --width 864 \
-                --opset 18
-              ./venv/bin/python -m scripts.export_onnx_pipeline \
-                --weights weights/cutie-base-mega.pth \
-                --output-dir weights \
-                --use-dynamo \
-                --height 480 \
-                --width 864 \
-                --num-objects 1 \
-                --memory-frames 1
-              ./venv/bin/python -m scripts.export_ritm_onnx \
-                --weights weights/coco_lvis_h18_itermask.pth \
-                --output weights/ritm_no_brs.onnx \
-                --height 480 \
-                --width 864 \
-                --opset 18
               ORT_CAPI=$(./venv/bin/python -c "import onnxruntime, pathlib; print(pathlib.Path(onnxruntime.__file__).resolve().parent / \"capi\")")
               ./venv/bin/python -m nuitka interactive_demo_onnx.py \
                 --standalone \

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ output
 pretrained/
 workspace
 workspace/
+build_nuitka_onnx/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/gui/TIPS.md
+++ b/gui/TIPS.md
@@ -8,6 +8,7 @@ Reset memory if needed.
 Controls:
 
 - Use left-click for foreground annotation and right-click for background annotation.
+- With the SAM2 ONNX click backend, use shift + left-drag to draw a rectangle box prompt.
 - Use number keys or the spinbox to change the object to be operated on. If it does not respond, most likely the correct number of objects was not specified during program startup.
 - Use left/right arrows to move between frames, shift+arrow to move by 10 frames, and alt/option+arrow to move to the start/end.
 - Use F/space and B to propagate forward and backward, respectively.

--- a/gui/gui.py
+++ b/gui/gui.py
@@ -23,6 +23,11 @@ class GUI(QWidget):
         # callbacks to be set by the controller
         self.on_mouse_motion_xy = None
         self.click_fn = None
+        self.box_prompt_start_fn = None
+        self.box_prompt_update_fn = None
+        self.box_prompt_end_fn = None
+        self._dragging_box_prompt = False
+        self._box_prompt_start = None
 
         self.controller = controller
         self.cfg = cfg
@@ -441,6 +446,16 @@ class GUI(QWidget):
             return
 
         ex, ey = self.get_scaled_pos(event.position().x(), event.position().y())
+        if (
+            event.button() == Qt.MouseButton.LeftButton
+            and event.modifiers() & Qt.KeyboardModifier.ShiftModifier
+            and self.box_prompt_start_fn is not None
+        ):
+            self._dragging_box_prompt = True
+            self._box_prompt_start = (ex, ey)
+            self.box_prompt_start_fn(ex, ey)
+            return
+
         if event.button() == Qt.MouseButton.LeftButton:
             action = 'left'
         elif event.button() == Qt.MouseButton.RightButton:
@@ -453,9 +468,20 @@ class GUI(QWidget):
     def on_mouse_motion(self, event):
         ex, ey = self.get_scaled_pos(event.position().x(), event.position().y())
         self.on_mouse_motion_xy(ex, ey)
+        if self._dragging_box_prompt and self.box_prompt_update_fn is not None:
+            self.box_prompt_update_fn(ex, ey)
 
     def on_mouse_release(self, event):
-        pass
+        if not self._dragging_box_prompt:
+            return
+        if event.button() != Qt.MouseButton.LeftButton:
+            return
+
+        self._dragging_box_prompt = False
+        ex, ey = self.get_scaled_pos(event.position().x(), event.position().y())
+        if self.box_prompt_end_fn is not None:
+            self.box_prompt_end_fn(ex, ey)
+        self._box_prompt_start = None
 
     def on_play_video(self):
         if self.timer.isActive():

--- a/gui_onnx/README.md
+++ b/gui_onnx/README.md
@@ -1,0 +1,48 @@
+# ONNX GUI Backend
+
+This folder provides an ONNX-backed VOS processor for `interactive_demo_onnx.py` while keeping the same GUI workflow.
+
+## Required ONNX files
+
+- `weights/cutie_image_encoder.onnx`
+- `weights/cutie_memory_write.onnx`
+- `weights/cutie_read_decode.onnx`
+- `weights/ritm_no_brs.onnx`
+
+## Export commands
+
+```bash
+python -m scripts.export_onnx --output weights/cutie_image_encoder.onnx --weights weights/cutie-base-mega.pth --height 480 --width 864 --opset 18
+python -m scripts.export_onnx_pipeline --weights weights/cutie-base-mega.pth --output-dir weights --use-dynamo --height 480 --width 864 --num-objects 1 --memory-frames 1
+python -m scripts.export_ritm_onnx --weights weights/coco_lvis_h18_itermask.pth --output weights/ritm_no_brs.onnx --height 480 --width 864 --opset 18
+```
+
+## Run GUI with ONNX backend
+
+```bash
+python interactive_demo_onnx.py --images <path_to_images>
+python interactive_demo_onnx.py --video <path_to_video>
+python interactive_demo_onnx.py <path_to_video>
+
+# ONNX click model (NoBRS)
+python interactive_demo_onnx.py --images <path_to_images>
+```
+
+Optional custom model paths:
+
+```bash
+python interactive_demo_onnx.py --ritm_onnx <ritm_no_brs.onnx> \
+  --onnx_encoder <encoder.onnx> \
+  --onnx_memory_write <memory_write.onnx> \
+  --onnx_read_decode <read_decode.onnx> \
+  --images <path_to_images>
+```
+
+## Notes
+
+- Current `gui_onnx` backend is single-object oriented and should be run with `--num_objects 1`.
+- `gui_onnx` reads limits from the ONNX files at runtime (not hardcoded in code).
+- If your current ONNX was exported with small capacities, re-export with larger values:
+  - `--num-objects` controls max object count for `memory_write/read_decode`.
+  - `--memory-frames` controls temporal memory length accepted by `read_decode`.
+- `num_objects` in GUI must be `<=` ONNX-exported object capacity.

--- a/gui_onnx/README.md
+++ b/gui_onnx/README.md
@@ -8,6 +8,9 @@ This folder provides an ONNX-backed VOS processor for `interactive_demo_onnx.py`
 - `weights/cutie_memory_write.onnx`
 - `weights/cutie_read_decode.onnx`
 - `weights/ritm_no_brs.onnx`
+- Optional for SAM2-assisted first-frame clicks:
+  - `weights/sam2.1_hiera_small.encoder.onnx`
+  - `weights/sam2.1_hiera_small.decoder.onnx`
 
 ## Export commands
 
@@ -15,6 +18,7 @@ This folder provides an ONNX-backed VOS processor for `interactive_demo_onnx.py`
 python -m scripts.export_onnx --output weights/cutie_image_encoder.onnx --weights weights/cutie-base-mega.pth --height 480 --width 864 --opset 18
 python -m scripts.export_onnx_pipeline --weights weights/cutie-base-mega.pth --output-dir weights --use-dynamo --height 480 --width 864 --num-objects 1 --memory-frames 1
 python -m scripts.export_ritm_onnx --weights weights/coco_lvis_h18_itermask.pth --output weights/ritm_no_brs.onnx --height 480 --width 864 --opset 18
+python -m samexporter.export_sam2 --checkpoint weights/sam2.1_hiera_small.pt --output_encoder weights/sam2.1_hiera_small.encoder.onnx --output_decoder weights/sam2.1_hiera_small.decoder.onnx --model_type sam2.1_hiera_small
 ```
 
 ## Run GUI with ONNX backend
@@ -26,6 +30,16 @@ python interactive_demo_onnx.py <path_to_video>
 
 # ONNX click model (NoBRS)
 python interactive_demo_onnx.py --images <path_to_images>
+
+# SAM2 clicks for first-frame object selection, Cutie ONNX for propagation
+python interactive_demo_onnx.py \
+  --images <path_to_images> \
+  --click_backend_model sam2
+
+# In the GUI:
+# - left click: positive point
+# - right click: negative point
+# - shift + left-drag: rectangle box prompt for SAM2
 ```
 
 Optional custom model paths:
@@ -42,6 +56,8 @@ python interactive_demo_onnx.py --ritm_onnx <ritm_no_brs.onnx> \
 
 - Current `gui_onnx` backend is single-object oriented and should be run with `--num_objects 1`.
 - `gui_onnx` reads limits from the ONNX files at runtime (not hardcoded in code).
+- With `--click_backend_model sam2`, clicks only affect first-frame mask generation; Cutie still handles all temporal tracking/memory.
+- The GitHub Actions release workflow exports and bundles the SAM2.1 small encoder/decoder into `weights/`.
 - If your current ONNX was exported with small capacities, re-export with larger values:
   - `--num-objects` controls max object count for `memory_write/read_decode`.
   - `--memory-frames` controls temporal memory length accepted by `read_decode`.

--- a/gui_onnx/__init__.py
+++ b/gui_onnx/__init__.py
@@ -1,0 +1,9 @@
+__all__ = ["MainControllerOnnxNumpy"]
+
+
+def __getattr__(name):
+    if name == "MainControllerOnnxNumpy":
+        from .main_controller import MainControllerOnnxNumpy
+
+        return MainControllerOnnxNumpy
+    raise AttributeError(name)

--- a/gui_onnx/click_controller_numpy.py
+++ b/gui_onnx/click_controller_numpy.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+
+
+class ClickControllerOnnxNumpy:
+    def __init__(
+        self,
+        onnx_path: str,
+        device: str = "cpu",
+        max_clicks: int = 8,
+        click_radius: int = 5,
+        with_flip: bool = True,
+    ):
+        try:
+            import onnxruntime as ort
+        except ImportError as exc:
+            raise ModuleNotFoundError(
+                "onnxruntime is required for the ONNX click backend."
+            ) from exc
+
+        providers = ["CPUExecutionProvider"]
+        if device == "cuda":
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+        self.session = ort.InferenceSession(onnx_path, providers=providers)
+        self.input_names = [item.name for item in self.session.get_inputs()]
+        if len(self.input_names) < 2:
+            raise RuntimeError("RITM ONNX must expose image and coord_features inputs.")
+        self.image_input = self.input_names[0]
+        self.coord_input = self.input_names[1]
+        image_shape = self.session.get_inputs()[0].shape
+        self.with_prev_mask = int(image_shape[1]) == 4
+        self.max_clicks = int(max_clicks)
+        self.click_radius = int(click_radius)
+        self.with_flip = bool(with_flip)
+
+        self.anchored = False
+        self._image_np = None
+        self._initial_prev_mask = None
+        self._prev_prediction = None
+        self._clicks: List[Tuple[int, int, bool]] = []
+
+    def unanchor(self):
+        self.anchored = False
+        self._image_np = None
+        self._initial_prev_mask = None
+        self._prev_prediction = None
+        self._clicks = []
+
+    def _build_coord_features(self, h: int, w: int) -> np.ndarray:
+        pos = np.zeros((h, w), dtype=np.float32)
+        neg = np.zeros((h, w), dtype=np.float32)
+        for x, y, is_pos in self._clicks[-self.max_clicks :]:
+            if is_pos:
+                cv2.circle(pos, (x, y), self.click_radius, 1.0, thickness=-1)
+            else:
+                cv2.circle(neg, (x, y), self.click_radius, 1.0, thickness=-1)
+        return np.stack([pos, neg], axis=0)[None, ...]
+
+    def _infer_logits(self, image_np: np.ndarray, prev_np: np.ndarray, coord_np: np.ndarray) -> np.ndarray:
+        if self.with_prev_mask:
+            image_in = np.concatenate([image_np, prev_np], axis=1)
+        else:
+            image_in = image_np
+        return self.session.run(
+            None,
+            {
+                self.image_input: image_in.astype(np.float32),
+                self.coord_input: coord_np.astype(np.float32),
+            },
+        )[0].astype(np.float32)
+
+    def _run(self) -> np.ndarray:
+        prev = self._prev_prediction
+        if prev is None:
+            prev = self._initial_prev_mask
+        if prev is None:
+            prev = np.zeros((1, 1, self._image_np.shape[-2], self._image_np.shape[-1]), dtype=np.float32)
+
+        coord = self._build_coord_features(self._image_np.shape[-2], self._image_np.shape[-1])
+        logits = self._infer_logits(self._image_np, prev, coord)
+
+        if self.with_flip:
+            logits_flip = self._infer_logits(
+                np.flip(self._image_np, axis=-1).copy(),
+                np.flip(prev, axis=-1).copy(),
+                np.flip(coord, axis=-1).copy(),
+            )
+            logits = 0.5 * (logits + np.flip(logits_flip, axis=-1).copy())
+
+        self._prev_prediction = 1.0 / (1.0 + np.exp(-logits))
+        return self._prev_prediction[:, 0]
+
+    def interact(
+        self,
+        image: np.ndarray,
+        x: int,
+        y: int,
+        is_positive: bool,
+        prev_mask: np.ndarray | None,
+    ) -> np.ndarray:
+        if not self.anchored:
+            self._image_np = image.astype(np.float32, copy=True)
+            self._initial_prev_mask = None if prev_mask is None else prev_mask.astype(np.float32, copy=True)
+            self._prev_prediction = None
+            self._clicks = []
+            self.anchored = True
+
+        self._clicks.append((int(x), int(y), bool(is_positive)))
+        return self._run()
+
+    def undo(self):
+        if len(self._clicks) == 0:
+            return None
+        self._clicks.pop()
+        if len(self._clicks) == 0:
+            self._prev_prediction = None
+            return None
+        self._prev_prediction = None
+        pred = self._run()
+        return (pred > 0.5).astype(np.float32)

--- a/gui_onnx/interaction_numpy.py
+++ b/gui_onnx/interaction_numpy.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from .click_controller_numpy import ClickControllerOnnxNumpy
+from .interactive_utils_numpy import aggregate_wbg
+
+
+class ClickInteractionOnnx:
+    def __init__(
+        self,
+        image: np.ndarray,
+        prev_mask: np.ndarray,
+        true_size: Tuple[int, int],
+        controller: ClickControllerOnnxNumpy,
+        tar_obj: int,
+    ):
+        self.image = image
+        self.prev_mask = prev_mask
+        self.controller = controller
+        self.h, self.w = true_size
+        self.tar_obj = tar_obj
+        self.first_click = True
+        self.obj_mask = None
+        self.out_prob = self.prev_mask.copy()
+
+    def push_point(self, x: int, y: int, is_neg: bool) -> None:
+        if self.first_click:
+            last_obj_mask = self.prev_mask[self.tar_obj : self.tar_obj + 1][None, ...]
+            self.obj_mask = self.controller.interact(
+                self.image[None, ...],
+                x,
+                y,
+                not is_neg,
+                prev_mask=last_obj_mask,
+            )
+            self.first_click = False
+        else:
+            self.obj_mask = self.controller.interact(
+                self.image[None, ...],
+                x,
+                y,
+                not is_neg,
+                prev_mask=None,
+            )
+
+    def predict(self) -> np.ndarray:
+        self.out_prob = self.prev_mask.copy()
+        self.out_prob = np.clip(self.out_prob, a_min=None, a_max=0.9)
+        self.out_prob[self.tar_obj] = self.obj_mask[0]
+        self.out_prob = aggregate_wbg(self.out_prob[1:], keep_bg=True, hard=True)
+        return self.out_prob.astype(np.float32)

--- a/gui_onnx/interaction_numpy.py
+++ b/gui_onnx/interaction_numpy.py
@@ -5,6 +5,7 @@ from typing import Tuple
 import numpy as np
 
 from .click_controller_numpy import ClickControllerOnnxNumpy
+from .sam2_click_controller_numpy import Sam2ClickControllerOnnxNumpy
 from .interactive_utils_numpy import aggregate_wbg
 
 
@@ -14,7 +15,7 @@ class ClickInteractionOnnx:
         image: np.ndarray,
         prev_mask: np.ndarray,
         true_size: Tuple[int, int],
-        controller: ClickControllerOnnxNumpy,
+        controller: ClickControllerOnnxNumpy | Sam2ClickControllerOnnxNumpy,
         tar_obj: int,
     ):
         self.image = image
@@ -45,6 +46,21 @@ class ClickInteractionOnnx:
                 not is_neg,
                 prev_mask=None,
             )
+
+    def set_box(self, x0: int, y0: int, x1: int, y1: int) -> None:
+        if not hasattr(self.controller, "set_box"):
+            raise NotImplementedError("Current click controller does not support box prompts.")
+
+        last_obj_mask = self.prev_mask[self.tar_obj : self.tar_obj + 1][None, ...]
+        self.obj_mask = self.controller.set_box(
+            self.image[None, ...],
+            x0,
+            y0,
+            x1,
+            y1,
+            prev_mask=last_obj_mask,
+        )
+        self.first_click = False
 
     def predict(self) -> np.ndarray:
         self.out_prob = self.prev_mask.copy()

--- a/gui_onnx/interactive_utils_numpy.py
+++ b/gui_onnx/interactive_utils_numpy.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from typing import List, Literal
+
+import numpy as np
+
+from cutie.utils.palette import davis_palette
+
+
+def image_to_chw_float(image: np.ndarray) -> np.ndarray:
+    return image.transpose(2, 0, 1).astype(np.float32) / 255.0
+
+
+def prob_to_mask(prob: np.ndarray) -> np.ndarray:
+    return np.argmax(prob, axis=0).astype(np.uint8)
+
+
+def index_mask_to_one_hot(mask: np.ndarray, num_classes: int) -> np.ndarray:
+    return np.eye(num_classes, dtype=np.float32)[mask].transpose(2, 0, 1)
+
+
+def _softmax(logits: np.ndarray, axis: int) -> np.ndarray:
+    logits = logits - np.max(logits, axis=axis, keepdims=True)
+    exp = np.exp(logits)
+    return exp / np.clip(np.sum(exp, axis=axis, keepdims=True), 1e-7, None)
+
+
+def aggregate_wbg(prob: np.ndarray, keep_bg: bool = False, hard: bool = False) -> np.ndarray:
+    new_prob = np.concatenate(
+        [np.prod(1.0 - prob, axis=0, keepdims=True), prob],
+        axis=0,
+    ).clip(1e-7, 1.0 - 1e-7)
+    logits = np.log(new_prob / (1.0 - new_prob))
+    if hard:
+        logits *= 1000.0
+    out = _softmax(logits, axis=0)
+    return out if keep_bg else out[1:]
+
+
+color_map_np = np.frombuffer(davis_palette, dtype=np.uint8).reshape(-1, 3).copy()
+color_map_np = (color_map_np.astype(np.float32) * 1.5).clip(0, 255).astype(np.uint8)
+grayscale_weights = np.array([[0.3, 0.59, 0.11]], dtype=np.float32)
+
+
+def _target_prob(prob: np.ndarray, target_objects: List[int]) -> np.ndarray:
+    if len(target_objects) == 0:
+        return np.zeros(prob.shape[1:] + (1,), dtype=np.float32)
+    return np.sum(prob[np.asarray(target_objects, dtype=np.int32)], axis=0, keepdims=False)[
+        ..., None
+    ]
+
+
+def overlay_davis(image: np.ndarray, mask: np.ndarray, alpha: float = 0.5, fade: bool = False):
+    im_overlay = image.copy()
+    colored_mask = color_map_np[mask]
+    foreground = image * alpha + (1.0 - alpha) * colored_mask
+    binary_mask = mask > 0
+    im_overlay[binary_mask] = foreground[binary_mask]
+    if fade:
+        im_overlay[~binary_mask] = im_overlay[~binary_mask] * 0.6
+    return im_overlay.astype(image.dtype)
+
+
+def overlay_popup(image: np.ndarray, mask: np.ndarray, target_objects: List[int]):
+    im_overlay = image.copy()
+    binary_mask = ~np.isin(mask, target_objects)
+    colored_region = (im_overlay[binary_mask] * grayscale_weights).sum(-1, keepdims=True)
+    im_overlay[binary_mask] = colored_region
+    return im_overlay.astype(image.dtype)
+
+
+def overlay_layer(image: np.ndarray, mask: np.ndarray, layer: np.ndarray, target_objects: List[int]):
+    obj_mask = np.isin(mask, target_objects).astype(np.float32)[:, :, None]
+    layer_alpha = layer[:, :, 3:4].astype(np.float32) / 255.0
+    layer_rgb = layer[:, :, :3].astype(np.float32)
+    background_alpha = (1.0 - obj_mask) * (1.0 - layer_alpha)
+    out = image.astype(np.float32) * background_alpha
+    out += layer_rgb * (1.0 - obj_mask) * layer_alpha
+    out += image.astype(np.float32) * obj_mask
+    return out.clip(0, 255).astype(image.dtype)
+
+
+def overlay_rgba(image: np.ndarray, mask: np.ndarray, target_objects: List[int]):
+    obj_mask = np.isin(mask, target_objects).astype(np.float32)[:, :, None] * 255.0
+    return np.concatenate([image, obj_mask.astype(np.uint8)], axis=-1)
+
+
+def overlay_popup_prob(image: np.ndarray, prob: np.ndarray, target_objects: List[int]):
+    image_f = image.astype(np.float32) / 255.0
+    obj_mask = _target_prob(prob, target_objects)
+    gray = (image_f * grayscale_weights).sum(-1, keepdims=True)
+    out = obj_mask * image_f + (1.0 - obj_mask) * gray
+    return (out.clip(0, 1) * 255.0).astype(np.uint8)
+
+
+def overlay_layer_prob(image: np.ndarray, prob: np.ndarray, layer: np.ndarray, target_objects: List[int]):
+    image_f = image.astype(np.float32) / 255.0
+    obj_mask = _target_prob(prob, target_objects)
+    layer_alpha = layer[:, :, 3:4].astype(np.float32) / 255.0
+    layer_rgb = layer[:, :, :3].astype(np.float32) / 255.0
+    background_alpha = (1.0 - obj_mask) * (1.0 - layer_alpha)
+    out = image_f * background_alpha + layer_rgb * (1.0 - obj_mask) * layer_alpha + image_f * obj_mask
+    return (out.clip(0, 1) * 255.0).astype(np.uint8)
+
+
+def overlay_rgba_prob(image: np.ndarray, prob: np.ndarray, target_objects: List[int]):
+    obj_mask = (_target_prob(prob, target_objects) * 255.0).clip(0, 255).astype(np.uint8)
+    return np.concatenate([image, obj_mask], axis=-1)
+
+
+def get_visualization(
+    mode: Literal["image", "mask", "fade", "davis", "light", "popup", "layer", "rgba"],
+    image: np.ndarray,
+    mask: np.ndarray,
+    layer: np.ndarray,
+    target_objects: List[int],
+) -> np.ndarray:
+    if mode == "image":
+        return image
+    if mode == "mask":
+        return color_map_np[mask]
+    if mode == "fade":
+        return overlay_davis(image, mask, fade=True)
+    if mode == "davis":
+        return overlay_davis(image, mask)
+    if mode == "light":
+        return overlay_davis(image, mask, 0.9)
+    if mode == "popup":
+        return overlay_popup(image, mask, target_objects)
+    if mode == "layer":
+        if layer is None:
+            return overlay_davis(image, mask)
+        return overlay_layer(image, mask, layer, target_objects)
+    if mode == "rgba":
+        return overlay_rgba(image, mask, target_objects)
+    raise NotImplementedError(mode)
+
+
+def get_visualization_prob(
+    mode: Literal["image", "mask", "fade", "davis", "light", "popup", "layer", "rgba"],
+    image: np.ndarray,
+    prob: np.ndarray,
+    layer: np.ndarray,
+    target_objects: List[int],
+) -> np.ndarray:
+    if mode in {"image", "mask", "fade", "davis", "light"}:
+        return get_visualization(mode, image, prob_to_mask(prob), layer, target_objects)
+    if mode == "popup":
+        return overlay_popup_prob(image, prob, target_objects)
+    if mode == "layer":
+        if layer is None:
+            return get_visualization("davis", image, prob_to_mask(prob), layer, target_objects)
+        return overlay_layer_prob(image, prob, layer, target_objects)
+    if mode == "rgba":
+        return overlay_rgba_prob(image, prob, target_objects)
+    raise NotImplementedError(mode)

--- a/gui_onnx/main_controller.py
+++ b/gui_onnx/main_controller.py
@@ -1,0 +1,555 @@
+from __future__ import annotations
+
+import logging
+import os
+from os import path
+from typing import Literal
+
+import cv2
+import numpy as np
+from omegaconf import DictConfig, open_dict
+
+from gui.exporter import convert_frames_to_video, convert_mask_to_binary
+from gui.gui import GUI
+from gui.resource_manager import ResourceManager
+
+from .click_controller_numpy import ClickControllerOnnxNumpy
+from .interaction_numpy import ClickInteractionOnnx
+from .interactive_utils_numpy import (
+    get_visualization,
+    get_visualization_prob,
+    image_to_chw_float,
+    index_mask_to_one_hot,
+    prob_to_mask,
+)
+from .onnx_inference_core_numpy import OnnxInferenceCoreNumpy
+from .reader_numpy import PropagationReaderNumpy
+
+log = logging.getLogger()
+
+
+class MainControllerOnnxNumpy:
+    def __init__(self, cfg: DictConfig) -> None:
+        super().__init__()
+        self.initialized = False
+
+        if cfg["workspace"] is None:
+            if cfg["images"] is not None:
+                basename = path.basename(cfg["images"])
+            elif cfg["video"] is not None:
+                basename = path.basename(cfg["video"])[:-4]
+            else:
+                raise NotImplementedError("Either images, video, or workspace has to be specified")
+            cfg["workspace"] = path.join(cfg["workspace_root"], basename)
+
+        self.cfg = cfg
+        self.num_objects = int(cfg["num_objects"])
+        self.device = cfg["device"]
+        self.amp = False
+
+        self.initialize_networks()
+
+        self.res_man = ResourceManager(cfg)
+        if "workspace_init_only" in cfg and cfg["workspace_init_only"]:
+            return
+        self.processor = self.build_processor()
+        self.gui = GUI(self, self.cfg)
+
+        self.length = self.res_man.length
+        self.interaction: ClickInteractionOnnx | None = None
+        self.interaction_type = "Click"
+        self.curr_ti = 0
+        self.curr_object = 1
+        self.propagating = False
+        self.propagate_direction: Literal["forward", "backward", "none"] = "none"
+        self.last_ex = 0
+        self.last_ey = 0
+
+        self.curr_frame_dirty = False
+        self.curr_image_np = np.zeros((self.h, self.w, 3), dtype=np.uint8)
+        self.curr_image_chw: np.ndarray | None = None
+        self.curr_mask = np.zeros((self.h, self.w), dtype=np.uint8)
+        self.curr_prob = np.zeros((self.num_objects + 1, self.h, self.w), dtype=np.float32)
+        self.curr_prob[0] = 1.0
+
+        self.vis_mode = "davis"
+        self.vis_image = None
+        self.save_visualization_mode = "None"
+        self.save_soft_mask = False
+
+        self.interacted_prob: np.ndarray | None = None
+        self.overlay_layer: np.ndarray | None = None
+        self.vis_target_objects = list(range(1, self.num_objects + 1))
+
+        self.load_current_image_mask()
+        self.show_current_frame()
+
+        self.update_memory_gauges()
+        self.update_gpu_gauges()
+        self.gui.work_mem_min.setValue(self.processor.memory.min_mem_frames)
+        self.gui.work_mem_max.setValue(self.processor.memory.max_mem_frames)
+        self.gui.long_mem_max.setValue(self.processor.memory.max_long_tokens)
+        self.gui.mem_every_box.setValue(self.processor.mem_every)
+
+        self.output_fps = cfg["output_fps"]
+        self.output_bitrate = cfg["output_bitrate"]
+
+        self.gui.on_mouse_motion_xy = self.on_mouse_motion_xy
+        self.gui.click_fn = self.click_fn
+
+        self.gui.show()
+        self.gui.text("Initialized.")
+        self.initialized = True
+
+        self._try_load_layer("./docs/uiuc.png")
+        self.gui.set_object_color(self.curr_object)
+        self.update_config()
+
+    def initialize_networks(self) -> None:
+        self.click_ctrl = ClickControllerOnnxNumpy(
+            self.cfg.ritm_onnx,
+            device=self.device,
+            max_clicks=self.cfg.ritm_max_clicks,
+            click_radius=self.cfg.ritm_click_radius,
+            with_flip=True,
+        )
+
+    def build_processor(self):
+        return OnnxInferenceCoreNumpy(self.cfg)
+
+    def hit_number_key(self, number: int):
+        if number == self.curr_object:
+            return
+        self.curr_object = number
+        self.gui.object_dial.setValue(number)
+        self.click_ctrl.unanchor()
+        self.gui.text(f"Current object changed to {number}.")
+        self.gui.set_object_color(number)
+        self.show_current_frame()
+
+    def click_fn(self, action: Literal["left", "right", "middle"], x: int, y: int):
+        if self.propagating:
+            return
+
+        last_interaction = self.interaction
+        if action in ["left", "right"]:
+            self.convert_current_image_mask_numpy()
+            image = self.curr_image_chw
+            if last_interaction is None or last_interaction.tar_obj != self.curr_object:
+                self.complete_interaction()
+                self.click_ctrl.unanchor()
+                self.interaction = ClickInteractionOnnx(
+                    image,
+                    self.curr_prob,
+                    (self.h, self.w),
+                    self.click_ctrl,
+                    self.curr_object,
+                )
+
+            self.interaction.push_point(x, y, is_neg=(action == "right"))
+            self.interacted_prob = self.interaction.predict()
+            self.update_interacted_mask()
+            self.update_gpu_gauges()
+            return
+
+        if action == "middle":
+            target_object = int(self.curr_mask[int(y), int(x)])
+            if target_object in self.vis_target_objects:
+                self.vis_target_objects.remove(target_object)
+            else:
+                self.vis_target_objects.append(target_object)
+            self.gui.text(f"Overlay target(s) changed to {self.vis_target_objects}")
+            self.show_current_frame()
+            return
+
+        raise NotImplementedError(action)
+
+    def load_current_image_mask(self, no_mask: bool = False):
+        self.curr_image_np = self.res_man.get_image(self.curr_ti)
+        self.curr_image_chw = None
+        if not no_mask:
+            loaded_mask = self.res_man.get_mask(self.curr_ti)
+            if loaded_mask is None:
+                self.curr_mask.fill(0)
+            else:
+                self.curr_mask = loaded_mask.copy()
+            self.curr_prob = None
+
+    def convert_current_image_mask_numpy(self, no_mask: bool = False):
+        if self.curr_image_chw is None:
+            self.curr_image_chw = image_to_chw_float(self.curr_image_np)
+        if self.curr_prob is None and not no_mask:
+            self.curr_prob = index_mask_to_one_hot(self.curr_mask, self.num_objects + 1)
+
+    def compose_current_im(self):
+        self.vis_image = get_visualization(
+            self.vis_mode,
+            self.curr_image_np,
+            self.curr_mask,
+            self.overlay_layer,
+            self.vis_target_objects,
+        )
+
+    def update_canvas(self):
+        self.gui.set_canvas(self.vis_image)
+
+    def update_current_image_fast(self, invalid_soft_mask: bool = False):
+        self.vis_image = get_visualization_prob(
+            self.vis_mode,
+            self.curr_image_np,
+            self.curr_prob,
+            self.overlay_layer,
+            self.vis_target_objects,
+        )
+        self.vis_image = np.ascontiguousarray(self.vis_image)
+        save_visualization = self.save_visualization_mode in [
+            "Propagation only (higher quality)",
+            "Always",
+        ]
+        if save_visualization and not invalid_soft_mask:
+            self.res_man.save_visualization(self.curr_ti, self.vis_mode, self.vis_image)
+        if self.save_soft_mask and not invalid_soft_mask:
+            self.res_man.save_soft_mask(self.curr_ti, self.curr_prob)
+        self.gui.set_canvas(self.vis_image)
+
+    def show_current_frame(self, fast: bool = False, invalid_soft_mask: bool = False):
+        if fast:
+            self.update_current_image_fast(invalid_soft_mask)
+        else:
+            self.compose_current_im()
+            if self.save_visualization_mode == "Always":
+                self.res_man.save_visualization(self.curr_ti, self.vis_mode, self.vis_image)
+            self.update_canvas()
+
+        self.gui.update_slider(self.curr_ti)
+        self.gui.frame_name.setText(self.res_man.names[self.curr_ti] + ".jpg")
+
+    def set_vis_mode(self):
+        self.vis_mode = self.gui.combo.currentText()
+        self.show_current_frame()
+
+    def save_current_mask(self):
+        self.res_man.save_mask(self.curr_ti, self.curr_mask)
+
+    def on_slider_update(self):
+        self.curr_ti = self.gui.tl_slider.value()
+        if not self.propagating:
+            if self.curr_frame_dirty:
+                self.save_current_mask()
+            self.curr_frame_dirty = False
+            self.reset_this_interaction()
+            self.curr_ti = self.gui.tl_slider.value()
+            self.load_current_image_mask()
+            self.show_current_frame()
+
+    def on_forward_propagation(self):
+        if self.propagating:
+            self.propagating = False
+            self.propagate_direction = "none"
+        else:
+            self.propagate_fn = self.on_next_frame
+            self.gui.forward_propagation_start()
+            self.propagate_direction = "forward"
+            self.on_propagate()
+
+    def on_backward_propagation(self):
+        if self.propagating:
+            self.propagating = False
+            self.propagate_direction = "none"
+        else:
+            self.propagate_fn = self.on_prev_frame
+            self.gui.backward_propagation_start()
+            self.propagate_direction = "backward"
+            self.on_propagate()
+
+    def on_pause(self):
+        self.propagating = False
+        self.gui.text(f"Propagation stopped at t={self.curr_ti}.")
+        self.gui.pause_propagation()
+
+    def on_propagate(self):
+        self.convert_current_image_mask_numpy()
+        self.gui.text(f"Propagation started at t={self.curr_ti}.")
+        self.processor.clear_sensory_memory()
+        self.curr_prob = self.processor.step(self.curr_image_chw, self.curr_prob[1:], idx_mask=False)
+        self.curr_mask = prob_to_mask(self.curr_prob)
+        self.interacted_prob = None
+        self.reset_this_interaction()
+        self.show_current_frame(fast=True, invalid_soft_mask=True)
+
+        self.propagating = True
+        self.gui.clear_all_mem_button.setEnabled(False)
+        self.gui.clear_non_perm_mem_button.setEnabled(False)
+        self.gui.tl_slider.setEnabled(False)
+
+        dataset = PropagationReaderNumpy(self.res_man, self.curr_ti, self.propagate_direction)
+        for image_np, image_chw in dataset:
+            if not self.propagating:
+                break
+            self.curr_image_np = image_np
+            self.curr_image_chw = image_chw
+            self.propagate_fn()
+            self.curr_prob = self.processor.step(self.curr_image_chw)
+            self.curr_mask = prob_to_mask(self.curr_prob)
+
+            self.save_current_mask()
+            self.show_current_frame(fast=True)
+
+            self.update_memory_gauges()
+            self.gui.process_events()
+
+            if self.curr_ti == 0 or self.curr_ti == self.T - 1:
+                break
+
+        self.propagating = False
+        self.curr_frame_dirty = False
+        self.on_pause()
+        self.on_slider_update()
+        self.gui.process_events()
+
+    def pause_propagation(self):
+        self.propagating = False
+
+    def on_commit(self):
+        if self.interacted_prob is None:
+            self.load_current_image_mask()
+        else:
+            self.complete_interaction()
+            self.update_interacted_mask()
+
+        self.convert_current_image_mask_numpy()
+        self.gui.text(f"Permanent memory saved at {self.curr_ti}.")
+        self.curr_prob = self.processor.step(
+            self.curr_image_chw,
+            self.curr_prob[1:],
+            idx_mask=False,
+            force_permanent=True,
+        )
+        self.update_memory_gauges()
+        self.update_gpu_gauges()
+
+    def on_play_video_timer(self):
+        self.curr_ti += 1
+        if self.curr_ti > self.T - 1:
+            self.curr_ti = 0
+        self.gui.tl_slider.setValue(self.curr_ti)
+
+    def on_export_visualization(self):
+        image_folder = path.join(self.cfg["workspace"], "visualization", self.vis_mode)
+        save_folder = self.cfg["workspace"]
+        if path.exists(image_folder):
+            output_path = path.join(save_folder, f"visualization_{self.vis_mode}.mp4")
+            self.gui.text("Exporting visualization -- please wait")
+            self.gui.process_events()
+            convert_frames_to_video(
+                image_folder,
+                output_path,
+                fps=self.output_fps,
+                bitrate=self.output_bitrate,
+                progress_callback=self.gui.progressbar_update,
+            )
+            self.gui.text(f"Visualization exported to {output_path}")
+            self.gui.progressbar_update(0)
+        else:
+            self.gui.text(f"No visualization images found in {image_folder}")
+
+    def on_export_binary(self):
+        mask_folder = path.join(self.cfg["workspace"], "masks")
+        save_folder = path.join(self.cfg["workspace"], "binary_masks")
+        if path.exists(mask_folder):
+            os.makedirs(save_folder, exist_ok=True)
+            self.gui.text("Exporting binary masks -- please wait")
+            self.gui.process_events()
+            convert_mask_to_binary(
+                mask_folder,
+                save_folder,
+                self.vis_target_objects,
+                progress_callback=self.gui.progressbar_update,
+            )
+            self.gui.text(f"Binary masks exported to {save_folder}")
+            self.gui.progressbar_update(0)
+        else:
+            self.gui.text(f"No masks found in {mask_folder}")
+
+    def on_object_dial_change(self):
+        self.hit_number_key(self.gui.object_dial.value())
+
+    def on_fps_dial_change(self):
+        self.output_fps = self.gui.fps_dial.value()
+
+    def on_bitrate_dial_change(self):
+        self.output_bitrate = self.gui.bitrate_dial.value()
+
+    def update_interacted_mask(self):
+        self.curr_prob = self.interacted_prob
+        self.curr_mask = prob_to_mask(self.interacted_prob)
+        self.save_current_mask()
+        self.show_current_frame()
+        self.curr_frame_dirty = False
+
+    def reset_this_interaction(self):
+        self.complete_interaction()
+        self.interacted_prob = None
+        self.click_ctrl.unanchor()
+
+    def on_reset_mask(self):
+        self.curr_mask.fill(0)
+        if self.curr_prob is not None:
+            self.curr_prob.fill(0)
+        self.curr_frame_dirty = True
+        self.save_current_mask()
+
+
+
+        self.reset_this_interaction()
+        self.show_current_frame()
+
+    def on_reset_object(self):
+        self.curr_mask[self.curr_mask == self.curr_object] = 0
+        if self.curr_prob is not None:
+            self.curr_prob[self.curr_object] = 0
+        self.curr_frame_dirty = True
+        self.save_current_mask()
+        self.reset_this_interaction()
+        self.show_current_frame()
+
+    def complete_interaction(self):
+        if self.interaction is not None:
+            self.interaction = None
+
+    def on_prev_frame(self, step=1):
+        self.gui.tl_slider.setValue(max(0, self.curr_ti - step))
+
+    def on_next_frame(self, step=1):
+        self.gui.tl_slider.setValue(min(self.curr_ti + step, self.length - 1))
+
+    def update_gpu_gauges(self):
+        label = "ONNX Runtime"
+        if self.device == "cuda":
+            label = "ONNX Runtime CUDA"
+        self.gui.gpu_mem_gauge.setFormat(label)
+        self.gui.gpu_mem_gauge.setValue(0)
+        self.gui.torch_mem_gauge.setFormat("N/A")
+        self.gui.torch_mem_gauge.setValue(0)
+
+    def on_gpu_timer(self):
+        self.update_gpu_gauges()
+
+    def update_memory_gauges(self):
+        try:
+            curr_perm_tokens = self.processor.memory.work_mem.perm_size(0)
+            self.gui.perm_mem_gauge.setFormat(f"{curr_perm_tokens} / {curr_perm_tokens}")
+            self.gui.perm_mem_gauge.setValue(100)
+
+            max_work_tokens = max(1, int(self.processor.memory.max_work_tokens))
+            max_long_tokens = max(1, int(self.processor.memory.max_long_tokens))
+            curr_work_tokens = self.processor.memory.work_mem.non_perm_size(0)
+            curr_long_tokens = self.processor.memory.long_mem.non_perm_size(0)
+
+            self.gui.work_mem_gauge.setFormat(f"{curr_work_tokens} / {max_work_tokens}")
+            self.gui.work_mem_gauge.setValue(round(curr_work_tokens / max_work_tokens * 100))
+            self.gui.long_mem_gauge.setFormat(f"{curr_long_tokens} / {max_long_tokens}")
+            self.gui.long_mem_gauge.setValue(round(curr_long_tokens / max_long_tokens * 100))
+        except AttributeError:
+            self.gui.work_mem_gauge.setFormat("Unknown")
+            self.gui.long_mem_gauge.setFormat("Unknown")
+            self.gui.work_mem_gauge.setValue(0)
+            self.gui.long_mem_gauge.setValue(0)
+
+    def on_work_min_change(self):
+        if self.initialized:
+            self.gui.work_mem_min.setValue(
+                min(self.gui.work_mem_min.value(), self.gui.work_mem_max.value() - 1)
+            )
+            self.update_config()
+
+    def on_work_max_change(self):
+        if self.initialized:
+            self.gui.work_mem_max.setValue(
+                max(self.gui.work_mem_max.value(), self.gui.work_mem_min.value() + 1)
+            )
+            self.update_config()
+
+    def update_config(self):
+        if self.initialized:
+            with open_dict(self.cfg):
+                self.cfg.long_term["min_mem_frames"] = self.gui.work_mem_min.value()
+                self.cfg.long_term["max_mem_frames"] = self.gui.work_mem_max.value()
+                self.cfg.long_term["max_num_tokens"] = self.gui.long_mem_max.value()
+                self.cfg["mem_every"] = self.gui.mem_every_box.value()
+            self.processor.update_config(self.cfg)
+
+    def on_clear_memory(self):
+        self.processor.clear_memory()
+        self.processor.update_config(self.cfg)
+        self.update_gpu_gauges()
+        self.update_memory_gauges()
+
+    def on_clear_non_permanent_memory(self):
+        self.processor.clear_non_permanent_memory()
+        self.processor.update_config(self.cfg)
+        self.update_gpu_gauges()
+        self.update_memory_gauges()
+
+    def on_import_mask(self):
+        file_name = self.gui.open_file("Mask")
+        if len(file_name) == 0:
+            return
+
+        mask = self.res_man.import_mask(file_name, size=(self.h, self.w))
+        shape_condition = len(mask.shape) == 2 and mask.shape[-1] == self.w and mask.shape[-2] == self.h
+        object_condition = mask.max() <= self.num_objects
+
+        if not shape_condition:
+            self.gui.text(f"Expected ({self.h}, {self.w}). Got {mask.shape} instead.")
+        elif not object_condition:
+            self.gui.text(
+                f"Expected {self.num_objects} objects. Got {mask.max()} objects instead."
+            )
+        else:
+            self.gui.text(f"Mask file {file_name} loaded.")
+            self.curr_image_chw = None
+            self.curr_prob = None
+            self.curr_mask = mask
+            self.show_current_frame()
+            self.save_current_mask()
+
+    def on_import_layer(self):
+        file_name = self.gui.open_file("Layer")
+        if len(file_name) == 0:
+            return
+        self._try_load_layer(file_name)
+
+    def _try_load_layer(self, file_name):
+        try:
+            layer = self.res_man.import_layer(file_name, size=(self.h, self.w))
+            self.gui.text(f"Layer file {file_name} loaded.")
+            self.overlay_layer = layer
+            self.show_current_frame()
+        except FileNotFoundError:
+            self.gui.text(f"{file_name} not found.")
+
+    def on_set_save_visualization_mode(self):
+        self.save_visualization_mode = self.gui.save_visualization_combo.currentText()
+
+    def on_save_soft_mask_toggle(self):
+        self.save_soft_mask = self.gui.save_soft_mask_checkbox.isChecked()
+
+    def on_mouse_motion_xy(self, x, y):
+        self.last_ex = x
+        self.last_ey = y
+
+    @property
+    def h(self) -> int:
+        return self.res_man.h
+
+    @property
+    def w(self) -> int:
+        return self.res_man.w
+
+    @property
+    def T(self) -> int:
+        return self.res_man.T
+
+
+__all__ = ["MainControllerOnnxNumpy"]

--- a/gui_onnx/main_controller.py
+++ b/gui_onnx/main_controller.py
@@ -24,6 +24,7 @@ from .interactive_utils_numpy import (
 )
 from .onnx_inference_core_numpy import OnnxInferenceCoreNumpy
 from .reader_numpy import PropagationReaderNumpy
+from .sam2_click_controller_numpy import Sam2ClickControllerOnnxNumpy
 
 log = logging.getLogger()
 
@@ -80,6 +81,7 @@ class MainControllerOnnxNumpy:
         self.interacted_prob: np.ndarray | None = None
         self.overlay_layer: np.ndarray | None = None
         self.vis_target_objects = list(range(1, self.num_objects + 1))
+        self.temp_box_prompt: tuple[int, int, int, int] | None = None
 
         self.load_current_image_mask()
         self.show_current_frame()
@@ -96,6 +98,9 @@ class MainControllerOnnxNumpy:
 
         self.gui.on_mouse_motion_xy = self.on_mouse_motion_xy
         self.gui.click_fn = self.click_fn
+        self.gui.box_prompt_start_fn = self.on_box_prompt_start
+        self.gui.box_prompt_update_fn = self.on_box_prompt_update
+        self.gui.box_prompt_end_fn = self.on_box_prompt_end
 
         self.gui.show()
         self.gui.text("Initialized.")
@@ -106,6 +111,16 @@ class MainControllerOnnxNumpy:
         self.update_config()
 
     def initialize_networks(self) -> None:
+        backend = str(getattr(self.cfg, "click_backend_model", "ritm")).lower()
+        if backend == "sam2":
+            self.click_ctrl = Sam2ClickControllerOnnxNumpy(
+                self.cfg.sam2_encoder_onnx,
+                self.cfg.sam2_decoder_onnx,
+                device=self.device,
+            )
+            log.info("Using SAM2 ONNX click backend for initial object selection.")
+            return
+
         self.click_ctrl = ClickControllerOnnxNumpy(
             self.cfg.ritm_onnx,
             device=self.device,
@@ -113,6 +128,7 @@ class MainControllerOnnxNumpy:
             click_radius=self.cfg.ritm_click_radius,
             with_flip=True,
         )
+        log.info("Using RITM ONNX click backend for initial object selection.")
 
     def build_processor(self):
         return OnnxInferenceCoreNumpy(self.cfg)
@@ -164,9 +180,79 @@ class MainControllerOnnxNumpy:
 
         raise NotImplementedError(action)
 
+    def _sam2_box_prompt_enabled(self) -> bool:
+        return isinstance(self.click_ctrl, Sam2ClickControllerOnnxNumpy)
+
+    def _normalized_box_prompt(
+        self, x0: int | float, y0: int | float, x1: int | float, y1: int | float
+    ) -> tuple[int, int, int, int]:
+        x_min, x_max = sorted((int(round(x0)), int(round(x1))))
+        y_min, y_max = sorted((int(round(y0)), int(round(y1))))
+        return x_min, y_min, x_max, y_max
+
+    def _draw_temp_box_prompt(self, image: np.ndarray) -> np.ndarray:
+        if self.temp_box_prompt is None:
+            return image
+        x0, y0, x1, y1 = self._normalized_box_prompt(*self.temp_box_prompt)
+        preview = image.copy()
+        cv2.rectangle(preview, (x0, y0), (x1, y1), (80, 255, 80), 2)
+        return preview
+
+    def _ensure_box_interaction(self) -> ClickInteractionOnnx:
+        last_interaction = self.interaction
+        self.convert_current_image_mask_numpy()
+        image = self.curr_image_chw
+        if last_interaction is None or last_interaction.tar_obj != self.curr_object:
+            self.complete_interaction()
+            self.click_ctrl.unanchor()
+            self.interaction = ClickInteractionOnnx(
+                image,
+                self.curr_prob,
+                (self.h, self.w),
+                self.click_ctrl,
+                self.curr_object,
+            )
+        return self.interaction
+
+    def on_box_prompt_start(self, x: int, y: int):
+        if self.propagating or not self._sam2_box_prompt_enabled():
+            return
+        self.temp_box_prompt = self._normalized_box_prompt(x, y, x, y)
+        self._show_preview_frame()
+
+    def on_box_prompt_update(self, x: int, y: int):
+        if self.temp_box_prompt is None or not self._sam2_box_prompt_enabled():
+            return
+        x0, y0, _, _ = self.temp_box_prompt
+        self.temp_box_prompt = self._normalized_box_prompt(x0, y0, x, y)
+        self._show_preview_frame()
+
+    def on_box_prompt_end(self, x: int, y: int):
+        if not self._sam2_box_prompt_enabled():
+            self.temp_box_prompt = None
+            return
+        if self.propagating or self.temp_box_prompt is None:
+            self.temp_box_prompt = None
+            return
+
+        x0, y0, _, _ = self.temp_box_prompt
+        x0, y0, x1, y1 = self._normalized_box_prompt(x0, y0, x, y)
+        self.temp_box_prompt = None
+        if x1 <= x0 or y1 <= y0:
+            self.gui.text("Box prompt ignored: drag a larger rectangle.")
+            self.show_current_frame()
+            return
+
+        interaction = self._ensure_box_interaction()
+        interaction.set_box(x0, y0, x1, y1)
+        self.interacted_prob = interaction.predict()
+        self.update_interacted_mask()
+        self.update_gpu_gauges()
+
     def load_current_image_mask(self, no_mask: bool = False):
         self.curr_image_np = self.res_man.get_image(self.curr_ti)
         self.curr_image_chw = None
+        self.temp_box_prompt = None
         if not no_mask:
             loaded_mask = self.res_man.get_mask(self.curr_ti)
             if loaded_mask is None:
@@ -189,6 +275,7 @@ class MainControllerOnnxNumpy:
             self.overlay_layer,
             self.vis_target_objects,
         )
+        self.vis_image = self._draw_temp_box_prompt(self.vis_image)
 
     def update_canvas(self):
         self.gui.set_canvas(self.vis_image)
@@ -201,6 +288,7 @@ class MainControllerOnnxNumpy:
             self.overlay_layer,
             self.vis_target_objects,
         )
+        self.vis_image = self._draw_temp_box_prompt(self.vis_image)
         self.vis_image = np.ascontiguousarray(self.vis_image)
         save_visualization = self.save_visualization_mode in [
             "Propagation only (higher quality)",
@@ -222,6 +310,11 @@ class MainControllerOnnxNumpy:
             self.update_canvas()
 
         self.gui.update_slider(self.curr_ti)
+        self.gui.frame_name.setText(self.res_man.names[self.curr_ti] + ".jpg")
+
+    def _show_preview_frame(self):
+        self.compose_current_im()
+        self.update_canvas()
         self.gui.frame_name.setText(self.res_man.names[self.curr_ti] + ".jpg")
 
     def set_vis_mode(self):
@@ -390,6 +483,7 @@ class MainControllerOnnxNumpy:
     def reset_this_interaction(self):
         self.complete_interaction()
         self.interacted_prob = None
+        self.temp_box_prompt = None
         self.click_ctrl.unanchor()
 
     def on_reset_mask(self):

--- a/gui_onnx/onnx_inference_core_numpy.py
+++ b/gui_onnx/onnx_inference_core_numpy.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+import cv2
+import numpy as np
+
+
+class _MemStoreCounter:
+    def __init__(self) -> None:
+        self._perm = 0
+        self._non_perm = 0
+
+    def set_tokens(self, perm: int, non_perm: int) -> None:
+        self._perm = int(max(0, perm))
+        self._non_perm = int(max(0, non_perm))
+
+    def perm_size(self, bucket_id: int) -> int:
+        return self._perm
+
+    def non_perm_size(self, bucket_id: int) -> int:
+        return self._non_perm
+
+
+class _MemoryGaugeProxy:
+    def __init__(self, cfg) -> None:
+        self.min_mem_frames = int(cfg.long_term.min_mem_frames - 1)
+        self.max_mem_frames = int(cfg.long_term.max_mem_frames - 1)
+        self.max_long_tokens = int(cfg.long_term.max_num_tokens)
+        self.max_work_tokens = 1
+        self.work_mem = _MemStoreCounter()
+        self.long_mem = _MemStoreCounter()
+
+    def update(self, hw: int, total_frames: int, perm_frames: int) -> None:
+        self.max_work_tokens = int(max(1, self.max_mem_frames * hw))
+        perm = int(max(0, perm_frames) * hw)
+        non_perm = int(max(0, total_frames - perm_frames) * hw)
+        self.work_mem.set_tokens(perm, non_perm)
+        self.long_mem.set_tokens(0, 0)
+
+
+@dataclass
+class _FrameEntry:
+    key: np.ndarray
+    shrinkage: np.ndarray
+    mask_value: np.ndarray
+    object_memory: np.ndarray
+    permanent: bool
+
+
+def _softmax(logits: np.ndarray, axis: int) -> np.ndarray:
+    logits = logits - np.max(logits, axis=axis, keepdims=True)
+    exp = np.exp(logits)
+    return exp / np.clip(np.sum(exp, axis=axis, keepdims=True), 1e-7, None)
+
+
+def _aggregate(prob: np.ndarray, axis: int) -> np.ndarray:
+    new_prob = np.concatenate(
+        [np.prod(1.0 - prob, axis=axis, keepdims=True), prob],
+        axis=axis,
+    ).clip(1e-7, 1.0 - 1e-7)
+    return np.log(new_prob / (1.0 - new_prob))
+
+
+def _pad_divide_by_chw(image: np.ndarray, divisor: int):
+    h, w = image.shape[-2:]
+    new_h = h if h % divisor == 0 else h + divisor - h % divisor
+    new_w = w if w % divisor == 0 else w + divisor - w % divisor
+    lh = int((new_h - h) / 2)
+    uh = int(new_h - h) - lh
+    lw = int((new_w - w) / 2)
+    uw = int(new_w - w) - lw
+    pad = (lw, uw, lh, uh)
+    padded = np.pad(image, ((0, 0), (lh, uh), (lw, uw)), mode="constant")
+    return padded, pad
+
+
+def _pad_divide_by_hw(mask: np.ndarray, divisor: int):
+    h, w = mask.shape[-2:]
+    new_h = h if h % divisor == 0 else h + divisor - h % divisor
+    new_w = w if w % divisor == 0 else w + divisor - w % divisor
+    lh = int((new_h - h) / 2)
+    uh = int(new_h - h) - lh
+    lw = int((new_w - w) / 2)
+    uw = int(new_w - w) - lw
+    pad = (lw, uw, lh, uh)
+    padded = np.pad(mask, ((lh, uh), (lw, uw)), mode="constant")
+    return padded, pad
+
+
+def _unpad_chw(image: np.ndarray, pad):
+    lw, uw, lh, uh = pad
+    h_slice = slice(lh, None if uh == 0 else -uh)
+    w_slice = slice(lw, None if uw == 0 else -uw)
+    return image[:, h_slice, w_slice]
+
+
+def _resize_chw(image: np.ndarray, size, interpolation) -> np.ndarray:
+    h, w = size
+    hwc = image.transpose(1, 2, 0)
+    resized = cv2.resize(hwc, (w, h), interpolation=interpolation)
+    if resized.ndim == 2:
+        resized = resized[:, :, None]
+    return resized.transpose(2, 0, 1).astype(np.float32)
+
+
+class OnnxInferenceCoreNumpy:
+    def __init__(self, cfg) -> None:
+        try:
+            import onnxruntime as ort
+        except ImportError as exc:
+            raise ModuleNotFoundError("onnxruntime is required for the ONNX backend.") from exc
+
+        self.cfg = cfg
+        self.device = cfg.device
+        self.mem_every = int(cfg.mem_every)
+        self.max_internal_size = int(cfg.max_internal_size)
+        self.num_objects_gui = int(cfg.num_objects)
+
+        encoder_path = Path(getattr(cfg, "onnx_encoder", "weights/cutie_image_encoder.onnx"))
+        write_path = Path(getattr(cfg, "onnx_memory_write", "weights/cutie_memory_write.onnx"))
+        read_path = Path(getattr(cfg, "onnx_read_decode", "weights/cutie_read_decode.onnx"))
+        for model_path in (encoder_path, write_path, read_path):
+            if not model_path.exists():
+                raise FileNotFoundError(f"ONNX model not found: {model_path}")
+
+        providers = ["CPUExecutionProvider"]
+        if self.device == "cuda":
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+        self.encoder = ort.InferenceSession(str(encoder_path), providers=providers)
+        self.memory_write = ort.InferenceSession(str(write_path), providers=providers)
+        self.read_decode = ort.InferenceSession(str(read_path), providers=providers)
+
+        image_shape = self.memory_write.get_inputs()[0].shape
+        sensory_shape = self.memory_write.get_inputs()[2].shape
+        self.input_h = int(image_shape[2])
+        self.input_w = int(image_shape[3])
+        self.num_objects_onnx = int(sensory_shape[1])
+        if self.num_objects_gui > self.num_objects_onnx:
+            raise ValueError(
+                f"GUI requested {self.num_objects_gui} objects, but ONNX supports {self.num_objects_onnx}."
+            )
+
+        rd_inputs = {x.name: x for x in self.read_decode.get_inputs()}
+        self.h16 = int(rd_inputs["key"].shape[2])
+        self.w16 = int(rd_inputs["key"].shape[3])
+        self.memory_frames = int(rd_inputs["memory_key"].shape[2])
+        self.sensory_channels = int(self.memory_write.get_inputs()[2].shape[2])
+
+        self.memory = _MemoryGaugeProxy(cfg)
+        self.curr_ti = -1
+        self.last_mem_ti = 0
+        self._frames: List[_FrameEntry] = []
+        self._sensory: Optional[np.ndarray] = None
+        self._last_mask = np.zeros((1, self.num_objects_onnx, self.h16, self.w16), dtype=np.float32)
+        self._selector = np.zeros((1, self.num_objects_onnx, 1, 1), dtype=np.float32)
+        self._selector[:, : self.num_objects_gui] = 1.0
+
+    def clear_memory(self):
+        self.curr_ti = -1
+        self.last_mem_ti = 0
+        self._frames = []
+        self._sensory = None
+        self._last_mask.fill(0)
+        self.memory.update(self.h16 * self.w16, 0, 0)
+
+    def clear_non_permanent_memory(self):
+        self.curr_ti = -1
+        self.last_mem_ti = 0
+        self._frames = [item for item in self._frames if item.permanent]
+        self.memory.update(
+            self.h16 * self.w16,
+            len(self._frames),
+            sum(1 for item in self._frames if item.permanent),
+        )
+
+    def clear_sensory_memory(self):
+        self.curr_ti = -1
+        self.last_mem_ti = 0
+        self._sensory = None
+        self._last_mask.fill(0)
+
+    def update_config(self, cfg):
+        self.mem_every = int(cfg["mem_every"])
+        self.memory.min_mem_frames = int(cfg.long_term.min_mem_frames - 1)
+        self.memory.max_mem_frames = int(cfg.long_term.max_mem_frames - 1)
+        self.memory.max_long_tokens = int(cfg.long_term.max_num_tokens)
+        self.memory.update(
+            self.h16 * self.w16,
+            len(self._frames),
+            sum(1 for item in self._frames if item.permanent),
+        )
+
+    def _transform_image(self, image: np.ndarray):
+        original_h, original_w = image.shape[-2:]
+        resized = image
+        resized_h, resized_w = original_h, original_w
+        resize_needed = False
+        if self.max_internal_size > 0:
+            min_side = min(original_h, original_w)
+            if min_side > self.max_internal_size:
+                resize_needed = True
+                resized_h = int(original_h / min_side * self.max_internal_size)
+                resized_w = int(original_w / min_side * self.max_internal_size)
+                resized = _resize_chw(resized, (resized_h, resized_w), cv2.INTER_LINEAR)
+
+        padded, pad = _pad_divide_by_chw(resized, 16)
+        src_h, src_w = padded.shape[-2:]
+        scale = min(self.input_h / src_h, self.input_w / src_w)
+        fit_h = min(self.input_h, max(1, int(round(src_h * scale))))
+        fit_w = min(self.input_w, max(1, int(round(src_w * scale))))
+        fitted = _resize_chw(padded, (fit_h, fit_w), cv2.INTER_LINEAR)
+        canvas = np.zeros((3, self.input_h, self.input_w), dtype=np.float32)
+        top = (self.input_h - fit_h) // 2
+        left = (self.input_w - fit_w) // 2
+        canvas[:, top : top + fit_h, left : left + fit_w] = fitted
+        meta = {
+            "original_h": original_h,
+            "original_w": original_w,
+            "resize_needed": resize_needed,
+            "resized_h": resized_h,
+            "resized_w": resized_w,
+            "pad": pad,
+            "padded_h": src_h,
+            "padded_w": src_w,
+            "canvas_top": top,
+            "canvas_left": left,
+            "canvas_h": fit_h,
+            "canvas_w": fit_w,
+        }
+        return canvas, meta
+
+    def _transform_mask(self, mask: np.ndarray, *, idx_mask: bool, meta):
+        if idx_mask:
+            out = mask
+            if meta["resize_needed"]:
+                out = cv2.resize(
+                    out.astype(np.float32),
+                    (meta["resized_w"], meta["resized_h"]),
+                    interpolation=cv2.INTER_NEAREST_EXACT,
+                ).astype(np.int64)
+            out, _ = _pad_divide_by_hw(out, 16)
+            fitted = cv2.resize(
+                out.astype(np.float32),
+                (meta["canvas_w"], meta["canvas_h"]),
+                interpolation=cv2.INTER_NEAREST_EXACT,
+            ).astype(np.int64)
+            canvas = np.zeros((self.input_h, self.input_w), dtype=np.int64)
+            top = meta["canvas_top"]
+            left = meta["canvas_left"]
+            canvas[top : top + meta["canvas_h"], left : left + meta["canvas_w"]] = fitted
+            return canvas
+
+        out = mask.astype(np.float32)
+        if meta["resize_needed"]:
+            out = _resize_chw(out, (meta["resized_h"], meta["resized_w"]), cv2.INTER_LINEAR)
+        padded_channels = []
+        for channel in out:
+            padded_channel, _ = _pad_divide_by_hw(channel, 16)
+            padded_channels.append(padded_channel)
+        out = np.stack(padded_channels, axis=0)
+        fitted = _resize_chw(out, (meta["canvas_h"], meta["canvas_w"]), cv2.INTER_LINEAR)
+        canvas = np.zeros((out.shape[0], self.input_h, self.input_w), dtype=np.float32)
+        top = meta["canvas_top"]
+        left = meta["canvas_left"]
+        canvas[:, top : top + meta["canvas_h"], left : left + meta["canvas_w"]] = fitted
+        return canvas
+
+    def _restore_output(self, prob: np.ndarray, meta) -> np.ndarray:
+        top = meta["canvas_top"]
+        left = meta["canvas_left"]
+        prob = prob[:, top : top + meta["canvas_h"], left : left + meta["canvas_w"]]
+        if prob.shape[-2:] != (meta["padded_h"], meta["padded_w"]):
+            prob = _resize_chw(prob, (meta["padded_h"], meta["padded_w"]), cv2.INTER_LINEAR)
+        prob = _unpad_chw(prob, meta["pad"])
+        if meta["resize_needed"]:
+            prob = _resize_chw(prob, (meta["original_h"], meta["original_w"]), cv2.INTER_LINEAR)
+        return prob
+
+    def _pad_to_onnx_objects(self, mask: np.ndarray) -> np.ndarray:
+        out = np.zeros((self.num_objects_onnx, mask.shape[-2], mask.shape[-1]), dtype=np.float32)
+        out[: self.num_objects_gui] = mask[: self.num_objects_gui].astype(np.float32)
+        return out
+
+    def _onnx_to_gui_channels(self, prob: np.ndarray) -> np.ndarray:
+        if self.num_objects_gui == self.num_objects_onnx:
+            return prob
+        fg = prob[1 : self.num_objects_gui + 1]
+        bg = prob[:1] + np.sum(prob[self.num_objects_gui + 1 :], axis=0, keepdims=True)
+        out = np.concatenate([bg, fg], axis=0)
+        return out / np.clip(np.sum(out, axis=0, keepdims=True), 1e-7, None)
+
+    def _build_memory_inputs(self):
+        pad_len = max(0, self.memory_frames - len(self._frames))
+        key_dim = self._frames[-1].key.shape[0]
+        value_dim = self._frames[-1].mask_value.shape[1]
+        q_dim = self._frames[-1].object_memory.shape[1]
+        e_dim = self._frames[-1].object_memory.shape[2]
+
+        mem_key = np.zeros((1, key_dim, self.memory_frames, self.h16, self.w16), dtype=np.float32)
+        mem_shrink = np.zeros((1, 1, self.memory_frames, self.h16, self.w16), dtype=np.float32)
+        mem_val = np.zeros(
+            (1, self.num_objects_onnx, value_dim, self.memory_frames, self.h16, self.w16),
+            dtype=np.float32,
+        )
+        obj_mem = np.zeros(
+            (1, self.num_objects_onnx, self.memory_frames, q_dim, e_dim),
+            dtype=np.float32,
+        )
+        for index, frame in enumerate(self._frames[-self.memory_frames :]):
+            t = index + pad_len
+            mem_key[:, :, t] = frame.key
+            mem_shrink[:, :, t] = frame.shrinkage
+            mem_val[:, :, :, t] = frame.mask_value
+            obj_mem[:, :, t] = frame.object_memory
+        return mem_key, mem_shrink, mem_val, obj_mem
+
+    def _append_memory(self, key, shrinkage, mask_value, object_memory, *, permanent: bool):
+        self._frames.append(
+            _FrameEntry(
+                key=key[0],
+                shrinkage=shrinkage[0],
+                mask_value=mask_value[0],
+                object_memory=object_memory[0],
+                permanent=permanent,
+            )
+        )
+        while len(self._frames) > self.memory_frames:
+            non_perm = [index for index, frame in enumerate(self._frames) if not frame.permanent]
+            drop_index = non_perm[0] if len(non_perm) > 0 else 0
+            self._frames.pop(drop_index)
+        self.memory.update(
+            self.h16 * self.w16,
+            len(self._frames),
+            sum(1 for frame in self._frames if frame.permanent),
+        )
+
+    def step(
+        self,
+        image: np.ndarray,
+        mask: Optional[np.ndarray] = None,
+        objects: Optional[Sequence[int]] = None,
+        *,
+        idx_mask: bool = True,
+        end: bool = False,
+        delete_buffer: bool = True,
+        force_permanent: bool = False,
+    ) -> np.ndarray:
+        del objects, delete_buffer
+        self.curr_ti += 1
+        image_onnx, meta = self._transform_image(image)
+        image_np = image_onnx[None, ...].astype(np.float32)
+
+        enc_out = self.encoder.run(None, {"image": image_np})
+        ms_feat_16x, ms_feat_8x, ms_feat_4x, pix_feat, key, shrinkage, selection = enc_out
+
+        is_mem_frame = (((self.curr_ti - self.last_mem_ti >= self.mem_every) or (mask is not None)) and (not end))
+
+        if mask is not None:
+            mask = self._transform_mask(mask, idx_mask=idx_mask, meta=meta)
+            if idx_mask:
+                one_hot = [(mask == obj_id).astype(np.float32) for obj_id in range(1, self.num_objects_gui + 1)]
+                mask_no_bg = np.stack(one_hot, axis=0) if len(one_hot) > 0 else np.empty((0, *mask.shape), dtype=np.float32)
+            else:
+                mask_no_bg = mask.astype(np.float32)
+            mask_no_bg = self._pad_to_onnx_objects(mask_no_bg)
+            logits = _aggregate(mask_no_bg, axis=0)
+            pred_prob_with_bg = _softmax(logits, axis=0).astype(np.float32)
+        else:
+            if len(self._frames) == 0:
+                out = np.zeros((self.num_objects_gui + 1, meta["original_h"], meta["original_w"]), dtype=np.float32)
+                out[0] = 1.0
+                return out
+
+            mem_key, mem_shrink, mem_val, obj_mem = self._build_memory_inputs()
+            if self._sensory is None:
+                self._sensory = np.zeros(
+                    (1, self.num_objects_onnx, mem_val.shape[2], self.h16, self.w16),
+                    dtype=np.float32,
+                )
+            rd_out = self.read_decode.run(
+                None,
+                {
+                    "ms_feat_16x": ms_feat_16x,
+                    "ms_feat_8x": ms_feat_8x,
+                    "ms_feat_4x": ms_feat_4x,
+                    "pix_feat": pix_feat,
+                    "key": key,
+                    "selection": selection,
+                    "memory_key": mem_key,
+                    "memory_shrinkage": mem_shrink,
+                    "memory_mask_value": mem_val,
+                    "object_memory": obj_mem,
+                    "sensory": self._sensory,
+                    "last_mask": self._last_mask,
+                    "selector": self._selector,
+                },
+            )
+            self._sensory = rd_out[1]
+            pred_prob_with_bg = rd_out[3][0].astype(np.float32)
+
+        if is_mem_frame or force_permanent:
+            if self._sensory is None:
+                self._sensory = np.zeros(
+                    (1, self.num_objects_onnx, self.sensory_channels, self.h16, self.w16),
+                    dtype=np.float32,
+                )
+            masks_for_memory = pred_prob_with_bg[1 : self.num_objects_onnx + 1][None, ...].astype(np.float32)
+            msk_value, new_sensory, obj_memory = self.memory_write.run(
+                None,
+                {
+                    "image": image_np,
+                    "pix_feat": pix_feat,
+                    "sensory": self._sensory,
+                    "masks": masks_for_memory,
+                },
+            )
+            self._sensory = new_sensory
+            permanent = bool(force_permanent) or len(self._frames) == 0
+            self._append_memory(key, shrinkage, msk_value, obj_memory, permanent=permanent)
+            self.last_mem_ti = self.curr_ti
+
+        last_mask = pred_prob_with_bg[1 : self.num_objects_onnx + 1]
+        last_mask = _resize_chw(last_mask, (self.h16, self.w16), cv2.INTER_LINEAR)
+        self._last_mask = last_mask[None, ...].astype(np.float32)
+
+        pred_prob_with_bg = self._onnx_to_gui_channels(pred_prob_with_bg)
+        output_prob = self._restore_output(pred_prob_with_bg, meta)
+        output_prob = output_prob / np.clip(np.sum(output_prob, axis=0, keepdims=True), 1e-7, None)
+        return output_prob.astype(np.float32)

--- a/gui_onnx/reader_numpy.py
+++ b/gui_onnx/reader_numpy.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Iterator, Literal, Tuple
+
+import numpy as np
+
+from gui.resource_manager import ResourceManager
+
+from .interactive_utils_numpy import image_to_chw_float
+
+
+class PropagationReaderNumpy:
+    def __init__(self, res_man: ResourceManager, start_ti: int, direction: Literal["forward", "backward"]):
+        self.res_man = res_man
+        self.start_ti = start_ti
+        self.direction = direction
+
+    def __iter__(self) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
+        if self.direction == "forward":
+            frame_range = range(self.start_ti + 1, self.res_man.T)
+        elif self.direction == "backward":
+            frame_range = range(self.start_ti - 1, -1, -1)
+        else:
+            raise NotImplementedError(self.direction)
+
+        for ti in frame_range:
+            image = self.res_man.get_image(ti)
+            yield image, image_to_chw_float(image)

--- a/gui_onnx/sam2_click_controller_numpy.py
+++ b/gui_onnx/sam2_click_controller_numpy.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+
+
+class Sam2ClickControllerOnnxNumpy:
+    def __init__(
+        self,
+        encoder_path: str,
+        decoder_path: str,
+        device: str = "cpu",
+    ):
+        try:
+            import onnxruntime as ort
+        except ImportError as exc:
+            raise ModuleNotFoundError(
+                "onnxruntime is required for the ONNX SAM2 click backend."
+            ) from exc
+
+        providers = ["CPUExecutionProvider"]
+        if device == "cuda":
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+        self.encoder_session = ort.InferenceSession(encoder_path, providers=providers)
+        self.decoder_session = ort.InferenceSession(decoder_path, providers=providers)
+
+        encoder_inputs = self.encoder_session.get_inputs()
+        self.encoder_input_name = encoder_inputs[0].name
+        self.encoder_input_height = int(encoder_inputs[0].shape[2])
+        self.encoder_input_width = int(encoder_inputs[0].shape[3])
+        self.encoder_output_names = [item.name for item in self.encoder_session.get_outputs()]
+
+        decoder_inputs = self.decoder_session.get_inputs()
+        self.decoder_input_names = [item.name for item in decoder_inputs]
+        self.decoder_output_names = [item.name for item in self.decoder_session.get_outputs()]
+
+        self.scale_factor = 4
+        self.anchored = False
+        self._clicks: List[Tuple[int, int, bool]] = []
+        self._box_prompt: Tuple[int, int, int, int] | None = None
+        self._image_size: Tuple[int, int] | None = None
+        self._encoder_outputs: Tuple[np.ndarray, np.ndarray, np.ndarray] | None = None
+
+    def unanchor(self):
+        self.anchored = False
+        self._clicks = []
+        self._box_prompt = None
+        self._image_size = None
+        self._encoder_outputs = None
+
+    def _prepare_encoder_input(self, image_np: np.ndarray) -> np.ndarray:
+        resized = cv2.resize(image_np, (self.encoder_input_width, self.encoder_input_height))
+        resized = resized.astype(np.float32)
+        if resized.max() > 1.0:
+            resized = resized / 255.0
+        mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+        std = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+        normalized = (resized - mean) / std
+        return normalized.transpose(2, 0, 1)[None, ...].astype(np.float32)
+
+    def _ensure_anchored(self, image: np.ndarray) -> None:
+        if self.anchored:
+            return
+
+        image_np = np.asarray(image)
+        if image_np.ndim != 4 or image_np.shape[0] != 1 or image_np.shape[1] != 3:
+            raise ValueError("SAM2 click backend expects image input shaped as (1, 3, H, W).")
+
+        # GUI uses RGB float image tensors in [0, 1].
+        hwc_image = np.clip(image_np[0].transpose(1, 2, 0), 0.0, 1.0)
+        self._image_size = (int(hwc_image.shape[0]), int(hwc_image.shape[1]))
+        encoder_input = self._prepare_encoder_input(hwc_image)
+        outputs = self.encoder_session.run(
+            self.encoder_output_names,
+            {self.encoder_input_name: encoder_input},
+        )
+        self._encoder_outputs = (outputs[0], outputs[1], outputs[2])
+        self._clicks = []
+        self._box_prompt = None
+        self.anchored = True
+
+    def _prepare_points(self) -> Tuple[np.ndarray, np.ndarray]:
+        if self._image_size is None:
+            raise RuntimeError("SAM2 click backend is not anchored to an image.")
+
+        coords_list: List[List[float]] = []
+        labels_list: List[float] = []
+        if self._box_prompt is not None:
+            x0, y0, x1, y1 = self._box_prompt
+            coords_list.extend([[x0, y0], [x1, y1]])
+            labels_list.extend([2.0, 3.0])
+        for x, y, is_pos in self._clicks:
+            coords_list.append([x, y])
+            labels_list.append(1.0 if is_pos else 0.0)
+
+        coords = np.array(coords_list, dtype=np.float32)
+        labels = np.array(labels_list, dtype=np.float32)
+
+        coords = coords[None, ...]
+        labels = labels[None, ...]
+        coords[..., 0] = coords[..., 0] / self._image_size[1] * self.encoder_input_width
+        coords[..., 1] = coords[..., 1] / self._image_size[0] * self.encoder_input_height
+        return coords.astype(np.float32), labels.astype(np.float32)
+
+    def _decode(self) -> np.ndarray:
+        if self._encoder_outputs is None or self._image_size is None:
+            raise RuntimeError("SAM2 click backend is missing cached encoder outputs.")
+
+        high_res_feats_0, high_res_feats_1, image_embedding = self._encoder_outputs
+        point_coords, point_labels = self._prepare_points()
+
+        mask_input = np.zeros(
+            (
+                point_labels.shape[0],
+                1,
+                self.encoder_input_height // self.scale_factor,
+                self.encoder_input_width // self.scale_factor,
+            ),
+            dtype=np.float32,
+        )
+        has_mask_input = np.array([0], dtype=np.float32)
+
+        decoder_inputs = {
+            self.decoder_input_names[0]: image_embedding,
+            self.decoder_input_names[1]: high_res_feats_0,
+            self.decoder_input_names[2]: high_res_feats_1,
+            self.decoder_input_names[3]: point_coords,
+            self.decoder_input_names[4]: point_labels,
+            self.decoder_input_names[5]: mask_input,
+            self.decoder_input_names[6]: has_mask_input,
+        }
+        masks, scores = self.decoder_session.run(self.decoder_output_names, decoder_inputs)[:2]
+
+        best_mask = masks[0, int(np.argmax(scores[0]))]
+        best_mask = cv2.resize(best_mask, (self._image_size[1], self._image_size[0]))
+        prob = 1.0 / (1.0 + np.exp(-best_mask))
+        return prob[None, ...].astype(np.float32)
+
+    def interact(
+        self,
+        image: np.ndarray,
+        x: int,
+        y: int,
+        is_positive: bool,
+        prev_mask: np.ndarray | None,
+    ) -> np.ndarray:
+        del prev_mask
+        self._ensure_anchored(image)
+        self._clicks.append((int(x), int(y), bool(is_positive)))
+        point_type = "positive" if is_positive else "negative"
+        print(f"SAM2 click: x={int(x)} y={int(y)} type={point_type}", flush=True)
+        return self._decode()
+
+    def set_box(
+        self,
+        image: np.ndarray,
+        x0: int,
+        y0: int,
+        x1: int,
+        y1: int,
+        prev_mask: np.ndarray | None,
+    ) -> np.ndarray:
+        del prev_mask
+        self._ensure_anchored(image)
+        x_min, x_max = sorted((int(x0), int(x1)))
+        y_min, y_max = sorted((int(y0), int(y1)))
+        self._box_prompt = (x_min, y_min, x_max, y_max)
+        print(
+            f"SAM2 box: x0={x_min} y0={y_min} x1={x_max} y1={y_max}",
+            flush=True,
+        )
+        return self._decode()
+
+    def undo(self):
+        if len(self._clicks) == 0:
+            return None
+        self._clicks.pop()
+        if len(self._clicks) == 0:
+            return None
+        pred = self._decode()
+        return (pred > 0.5).astype(np.float32)

--- a/interactive_demo_onnx.py
+++ b/interactive_demo_onnx.py
@@ -1,0 +1,191 @@
+import logging
+import os
+import signal
+import sys
+from argparse import ArgumentParser
+from hashlib import sha1
+from pathlib import Path
+
+if "QT_QPA_PLATFORM_PLUGIN_PATH" not in os.environ:
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = ""
+
+signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+
+def get_arguments():
+    parser = ArgumentParser()
+    parser.add_argument("--images", help="Folders containing input images.", default=None)
+    parser.add_argument("--video", help="Video file readable by OpenCV.", default=None)
+    parser.add_argument(
+        "--workspace",
+        help="directory for storing buffered images (if needed) and output masks",
+        default=None,
+    )
+    parser.add_argument("--num_objects", type=int, default=1)
+    parser.add_argument(
+        "--workspace_init_only",
+        action="store_true",
+        help="initialize the workspace and exit",
+    )
+    parser.add_argument(
+        "--onnx_encoder",
+        default="weights/cutie_image_encoder.onnx",
+        help="path to ONNX image encoder",
+    )
+    parser.add_argument(
+        "--onnx_memory_write",
+        default="weights/cutie_memory_write.onnx",
+        help="path to ONNX memory_write module",
+    )
+    parser.add_argument(
+        "--onnx_read_decode",
+        default="weights/cutie_read_decode.onnx",
+        help="path to ONNX read_decode module",
+    )
+    parser.add_argument(
+        "--ritm_onnx",
+        default="weights/ritm_no_brs.onnx",
+        help="path to ONNX RITM click model",
+    )
+    parser.add_argument(
+        "--ritm_max_clicks",
+        type=int,
+        default=8,
+        help="max click history used to build ONNX click maps",
+    )
+    parser.add_argument(
+        "--ritm_click_radius",
+        type=int,
+        default=5,
+        help="disk radius for ONNX click maps",
+    )
+    parser.add_argument(
+        "--device",
+        choices=["auto", "cpu", "cuda"],
+        default="auto",
+        help="ONNX Runtime execution provider",
+    )
+    argv = sys.argv[1:]
+    if len(argv) > 0 and not argv[0].startswith("-"):
+        argv = ["--video", argv[0], *argv[1:]]
+    return parser.parse_args(argv)
+
+
+def resolve_device(requested: str) -> str:
+    import onnxruntime as ort
+
+    if requested != "auto":
+        return requested
+
+    providers = set(ort.get_available_providers())
+    if "CUDAExecutionProvider" in providers:
+        return "cuda"
+    return "cpu"
+
+
+def resolve_config_dir() -> Path:
+    base_dir = Path(__file__).resolve().parent
+    config_dir = base_dir / "cutie" / "config"
+    if config_dir.exists():
+        return config_dir
+    return Path("cutie/config")
+
+
+def resolve_runtime_path(raw_path: str) -> str:
+    path_obj = Path(raw_path)
+    if path_obj.is_absolute() or path_obj.exists():
+        return str(path_obj)
+
+    base_dir = Path(__file__).resolve().parent
+    bundled_path = base_dir / raw_path
+    if bundled_path.exists():
+        return str(bundled_path)
+
+    return raw_path
+
+
+def default_workspace_root() -> Path:
+    return Path.home() / "scutie"
+
+
+def sha1_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    digest = sha1()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def resolve_workspace(args) -> str | None:
+    if args.workspace is not None:
+        return args.workspace
+
+    workspace_root = default_workspace_root()
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    if args.video is not None:
+        video_path = Path(args.video).expanduser().resolve()
+        return str(workspace_root / sha1_file(video_path))
+
+    if args.images is not None:
+        images_path = Path(args.images).expanduser().resolve()
+        return str(workspace_root / images_path.name)
+
+    return None
+
+
+if __name__ in "__main__":
+    args = get_arguments()
+
+    from hydra import compose, initialize, initialize_config_dir
+    from omegaconf import open_dict
+    from PySide6.QtWidgets import QApplication
+    import qdarktheme
+
+    from gui_onnx.main_controller import MainControllerOnnxNumpy
+
+    log = logging.getLogger()
+
+    config_dir = resolve_config_dir()
+    if config_dir.is_absolute():
+        with initialize_config_dir(
+            version_base="1.3.2",
+            config_dir=str(config_dir),
+            job_name="gui_onnx",
+        ):
+            cfg = compose(config_name="gui_config")
+    else:
+        with initialize(
+            version_base="1.3.2",
+            config_path=config_dir.as_posix(),
+            job_name="gui_onnx",
+        ):
+            cfg = compose(config_name="gui_config")
+
+    args.device = resolve_device(args.device)
+    log.info(f"Using ONNX Runtime device: {args.device}")
+    args.video = resolve_runtime_path(args.video) if args.video is not None else None
+    args.images = resolve_runtime_path(args.images) if args.images is not None else None
+    args.workspace = resolve_workspace(args)
+
+    args_dict = vars(args)
+    for key in ("onnx_encoder", "onnx_memory_write", "onnx_read_decode", "ritm_onnx"):
+        args_dict[key] = resolve_runtime_path(args_dict[key])
+
+    with open_dict(cfg):
+        for key, value in args_dict.items():
+            assert key not in cfg, f"Argument {key} already exists in config"
+            cfg[key] = value
+        cfg["backend"] = "onnx"
+        cfg["click_backend"] = "onnx"
+        cfg["amp"] = False
+
+    app = QApplication(sys.argv)
+    qdarktheme.setup_theme("auto")
+    ex = MainControllerOnnxNumpy(cfg)
+    if "workspace_init_only" in cfg and cfg["workspace_init_only"]:
+        sys.exit(0)
+    sys.exit(app.exec())

--- a/interactive_demo_onnx.py
+++ b/interactive_demo_onnx.py
@@ -48,6 +48,22 @@ def get_arguments():
         help="path to ONNX RITM click model",
     )
     parser.add_argument(
+        "--click_backend_model",
+        choices=["ritm", "sam2"],
+        default="sam2",
+        help="first-frame click backend: RITM or SAM2",
+    )
+    parser.add_argument(
+        "--sam2_encoder_onnx",
+        default="weights/sam2.1_hiera_small.encoder.onnx",
+        help="path to ONNX SAM2 encoder model used for click prompts",
+    )
+    parser.add_argument(
+        "--sam2_decoder_onnx",
+        default="weights/sam2.1_hiera_small.decoder.onnx",
+        help="path to ONNX SAM2 decoder model used for click prompts",
+    )
+    parser.add_argument(
         "--ritm_max_clicks",
         type=int,
         default=8,
@@ -172,7 +188,14 @@ if __name__ in "__main__":
     args.workspace = resolve_workspace(args)
 
     args_dict = vars(args)
-    for key in ("onnx_encoder", "onnx_memory_write", "onnx_read_decode", "ritm_onnx"):
+    for key in (
+        "onnx_encoder",
+        "onnx_memory_write",
+        "onnx_read_decode",
+        "ritm_onnx",
+        "sam2_encoder_onnx",
+        "sam2_decoder_onnx",
+    ):
         args_dict[key] = resolve_runtime_path(args_dict[key])
 
     with open_dict(cfg):

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+import argparse
+import importlib.util
+from pathlib import Path
+from typing import Any, Dict
+
+import torch
+from hydra import compose, initialize_config_dir
+from omegaconf import open_dict
+
+from cutie.model.cutie import CUTIE
+
+
+class CutieImageEncoderForOnnx(torch.nn.Module):
+    def __init__(self, model: CUTIE):
+        super().__init__()
+        self.model = model
+
+    def forward(self, image: torch.Tensor):
+        ms_features, pix_feat = self.model.encode_image(image)
+        key, shrinkage, selection = self.model.transform_key(ms_features[0])
+        return (
+            ms_features[0],
+            ms_features[1],
+            ms_features[2],
+            pix_feat,
+            key,
+            shrinkage,
+            selection,
+        )
+
+
+def _extract_state_dict(loaded: Any) -> Dict[str, torch.Tensor]:
+    if isinstance(loaded, dict):
+        if "state_dict" in loaded and isinstance(loaded["state_dict"], dict):
+            return loaded["state_dict"]
+        if "model" in loaded and isinstance(loaded["model"], dict):
+            return loaded["model"]
+    if not isinstance(loaded, dict):
+        raise TypeError(f"Unsupported checkpoint format: {type(loaded)}")
+    return loaded
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export CUTIE image encoder path to ONNX (encode_image + transform_key)."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Output ONNX file path.",
+    )
+    parser.add_argument(
+        "--weights",
+        type=Path,
+        default=Path("weights/cutie-base-mega.pth"),
+        help="Checkpoint path for CUTIE weights.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="base",
+        choices=["base", "small"],
+        help="CUTIE model config variant.",
+    )
+    parser.add_argument("--height", type=int, default=480, help="Dummy input height for export.")
+    parser.add_argument("--width", type=int, default=854, help="Dummy input width for export.")
+    parser.add_argument("--batch", type=int, default=1, help="Dummy input batch size for export.")
+    parser.add_argument("--opset", type=int, default=17, help="ONNX opset version.")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        choices=["cpu", "cuda"],
+        help="Device used during export.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if importlib.util.find_spec("onnx") is None:
+        raise ModuleNotFoundError(
+            "Missing dependency: onnx. Install it first (e.g. `pip install onnx`) to export."
+        )
+    if args.height <= 0 or args.width <= 0 or args.batch <= 0:
+        raise ValueError("height/width/batch must be positive integers.")
+
+    if args.device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but is not available.")
+
+    config_dir = (Path(__file__).resolve().parents[1] / "cutie" / "config").as_posix()
+    with initialize_config_dir(version_base="1.3.2", config_dir=config_dir, job_name="onnx_export"):
+        cfg = compose(config_name="eval_config", overrides=[f"model={args.model}"])
+    with open_dict(cfg):
+        cfg.weights = str(args.weights)
+
+    model = CUTIE(cfg)
+    if args.weights.exists():
+        checkpoint = torch.load(args.weights, map_location="cpu")
+        model.load_weights(_extract_state_dict(checkpoint))
+    else:
+        raise FileNotFoundError(f"Weights not found: {args.weights}")
+
+    device = torch.device(args.device)
+    model = model.to(device).eval()
+    wrapper = CutieImageEncoderForOnnx(model).to(device).eval()
+
+    dummy = torch.randn(args.batch, 3, args.height, args.width, device=device)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    torch.onnx.export(
+        wrapper,
+        (dummy,),
+        str(args.output),
+        dynamo=False,
+        export_params=True,
+        opset_version=args.opset,
+        do_constant_folding=True,
+        input_names=["image"],
+        output_names=[
+            "ms_feat_16x",
+            "ms_feat_8x",
+            "ms_feat_4x",
+            "pix_feat",
+            "key",
+            "shrinkage",
+            "selection",
+        ],
+        dynamic_axes={
+            "image": {
+                0: "batch",
+                2: "height",
+                3: "width",
+            },
+            "ms_feat_16x": {
+                0: "batch",
+                2: "height_div16",
+                3: "width_div16",
+            },
+            "ms_feat_8x": {
+                0: "batch",
+                2: "height_div8",
+                3: "width_div8",
+            },
+            "ms_feat_4x": {
+                0: "batch",
+                2: "height_div4",
+                3: "width_div4",
+            },
+            "pix_feat": {
+                0: "batch",
+                2: "height_div16",
+                3: "width_div16",
+            },
+            "key": {
+                0: "batch",
+                2: "height_div16",
+                3: "width_div16",
+            },
+            "shrinkage": {
+                0: "batch",
+                2: "height_div16",
+                3: "width_div16",
+            },
+            "selection": {
+                0: "batch",
+                2: "height_div16",
+                3: "width_div16",
+            },
+        },
+    )
+
+    print(f"Exported ONNX to: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_onnx_pipeline.py
+++ b/scripts/export_onnx_pipeline.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+import argparse
+import importlib.util
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+import torch
+import torch.nn.functional as F
+from hydra import compose, initialize_config_dir
+
+from cutie.model.cutie import CUTIE
+from cutie.model.utils.memory_utils import get_affinity, readout
+
+
+def _weighted_pooling(
+    masks: torch.Tensor,
+    value: torch.Tensor,
+    logits: torch.Tensor,
+) -> (torch.Tensor, torch.Tensor):
+    weights = logits.sigmoid() * masks
+    sums = torch.einsum("bkhwq,bkhwc->bkqc", weights, value)
+    area = weights.flatten(start_dim=2, end_dim=3).sum(2).unsqueeze(-1)
+    return sums, area
+
+
+class CutieMemoryWriteForOnnx(torch.nn.Module):
+    """
+    Memory write/update core:
+    encode_mask(image, pix_feat, sensory, masks) -> memory values + updated sensory + object memory.
+    """
+
+    def __init__(self, model: CUTIE, h16: int, w16: int):
+        super().__init__()
+        self.model = model
+        self.h16 = h16
+        self.w16 = w16
+
+    def forward(
+        self,
+        image: torch.Tensor,
+        pix_feat: torch.Tensor,
+        sensory: torch.Tensor,
+        masks: torch.Tensor,
+    ):
+        # Equivalent to CUTIE.encode_mask but with fixed-size mask resizing for ONNX export.
+        image = (image - self.model.pixel_mean) / self.model.pixel_std
+        others = self.model._get_others(masks)
+        msk_value, new_sensory = self.model.mask_encoder(
+            image,
+            pix_feat,
+            sensory,
+            masks,
+            others,
+            deep_update=True,
+            chunk_size=-1,
+        )
+
+        if self.model.object_transformer_enabled:
+            summarizer = self.model.object_summarizer
+            masks_fixed = F.interpolate(masks, size=(self.h16, self.w16), mode="area")
+            masks_fixed = masks_fixed.unsqueeze(-1)
+            inv_masks = 1 - masks_fixed
+            repeated_masks = torch.cat(
+                [
+                    masks_fixed.expand(-1, -1, -1, -1, summarizer.num_summaries // 2),
+                    inv_masks.expand(-1, -1, -1, -1, summarizer.num_summaries // 2),
+                ],
+                dim=-1,
+            )
+
+            value = msk_value.permute(0, 1, 3, 4, 2)
+            value = summarizer.input_proj(value)
+            if summarizer.add_pe:
+                value = value + summarizer.pos_enc(value)
+
+            value = value.float()
+            feature = summarizer.feature_pred(value)
+            logits = summarizer.weights_pred(value)
+            sums, area = _weighted_pooling(repeated_masks, feature, logits)
+            obj_memory = torch.cat([sums, area], dim=-1)
+        else:
+            obj_memory = torch.zeros(
+                (masks.shape[0], masks.shape[1], 1, self.model.embed_dim + 1),
+                dtype=msk_value.dtype,
+                device=msk_value.device,
+            )
+        return msk_value, new_sensory, obj_memory
+
+
+class CutieReadDecodeForOnnx(torch.nn.Module):
+    """
+    Memory read + decode core:
+    read_memory(...) + segment(...) -> readout + updated sensory + logits/prob with background.
+    """
+
+    def __init__(self, model: CUTIE):
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self,
+        ms_feat_16x: torch.Tensor,
+        ms_feat_8x: torch.Tensor,
+        ms_feat_4x: torch.Tensor,
+        pix_feat: torch.Tensor,
+        key: torch.Tensor,
+        selection: torch.Tensor,
+        memory_key: torch.Tensor,
+        memory_shrinkage: torch.Tensor,
+        memory_mask_value: torch.Tensor,
+        object_memory: torch.Tensor,
+        sensory: torch.Tensor,
+        last_mask: torch.Tensor,
+        selector: torch.Tensor,
+    ):
+        batch_size, num_objects = memory_mask_value.shape[:2]
+        with torch.cuda.amp.autocast(enabled=False):
+            affinity = get_affinity(
+                memory_key.float(),
+                memory_shrinkage.float(),
+                key.float(),
+                selection.float(),
+            )
+            value = memory_mask_value.flatten(start_dim=1, end_dim=2).float()
+            pixel_readout = readout(affinity, value).view(
+                batch_size,
+                num_objects,
+                self.model.value_dim,
+                *pix_feat.shape[-2:],
+            )
+        pixel_readout = self.model.pixel_fusion(pix_feat, pixel_readout, sensory, last_mask)
+        memory_readout, _ = self.model.readout_query(
+            pixel_readout,
+            object_memory,
+            selector=selector,
+        )
+        new_sensory, logits, prob = self.model.segment(
+            [ms_feat_16x, ms_feat_8x, ms_feat_4x],
+            memory_readout,
+            sensory,
+            selector=selector,
+            chunk_size=-1,
+            update_sensory=True,
+        )
+        return memory_readout, new_sensory, logits, prob
+
+
+def _extract_state_dict(loaded: Any) -> Dict[str, torch.Tensor]:
+    if isinstance(loaded, dict):
+        if "state_dict" in loaded and isinstance(loaded["state_dict"], dict):
+            return loaded["state_dict"]
+        if "model" in loaded and isinstance(loaded["model"], dict):
+            return loaded["model"]
+    if not isinstance(loaded, dict):
+        raise TypeError(f"Unsupported checkpoint format: {type(loaded)}")
+    return loaded
+
+
+def _toposort_onnx_graph(onnx_path: Path) -> None:
+    import onnx
+
+    model = onnx.load(str(onnx_path))
+    graph = model.graph
+    nodes = list(graph.node)
+
+    produced = {}
+    for idx, node in enumerate(nodes):
+        for out_name in node.output:
+            if out_name:
+                produced[out_name] = idx
+
+    available: Set[str] = set()
+    available.update(v.name for v in graph.input if v.name)
+    available.update(v.name for v in graph.initializer if v.name)
+    available.update(v.name for v in graph.sparse_initializer if v.name)
+
+    remaining = set(range(len(nodes)))
+    sorted_indices: List[int] = []
+
+    while remaining:
+        ready = []
+        for idx in remaining:
+            node = nodes[idx]
+            unresolved = False
+            for inp in node.input:
+                if not inp:
+                    continue
+                if inp in available:
+                    continue
+                producer = produced.get(inp)
+                if producer is None:
+                    continue
+                unresolved = True
+                break
+            if not unresolved:
+                ready.append(idx)
+
+        if not ready:
+            raise RuntimeError(
+                f"Could not topologically sort ONNX graph at {onnx_path}: cycle or unresolved dependency."
+            )
+
+        ready.sort()
+        for idx in ready:
+            remaining.remove(idx)
+            sorted_indices.append(idx)
+            for out_name in nodes[idx].output:
+                if out_name:
+                    available.add(out_name)
+
+    sorted_nodes = [nodes[idx] for idx in sorted_indices]
+    del graph.node[:]
+    graph.node.extend(sorted_nodes)
+    onnx.save(model, str(onnx_path))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export CUTIE pipeline ONNX modules (memory_write and read_decode)."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("weights"),
+        help="Directory to write ONNX files.",
+    )
+    parser.add_argument(
+        "--weights",
+        type=Path,
+        default=Path("weights/cutie-base-mega.pth"),
+        help="Checkpoint path for CUTIE weights.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="base",
+        choices=["base", "small"],
+        help="CUTIE model config variant.",
+    )
+    parser.add_argument("--height", type=int, default=480, help="Dummy input height for export.")
+    parser.add_argument("--width", type=int, default=854, help="Dummy input width for export.")
+    parser.add_argument("--batch", type=int, default=1, help="Dummy input batch size for export.")
+    parser.add_argument(
+        "--num-objects",
+        type=int,
+        default=2,
+        help="Dummy number of objects used at export time.",
+    )
+    parser.add_argument(
+        "--memory-frames",
+        type=int,
+        default=4,
+        help="Dummy temporal memory length used at export time.",
+    )
+    parser.add_argument("--opset", type=int, default=18, help="ONNX opset version.")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        choices=["cpu", "cuda"],
+        help="Device used during export.",
+    )
+    parser.add_argument(
+        "--disable-object-transformer",
+        action="store_true",
+        help="Disable object transformer (model.object_transformer.num_blocks=0) for exportability.",
+    )
+    parser.add_argument(
+        "--skip-read-decode",
+        action="store_true",
+        help="Export only memory_write ONNX and skip read_decode export.",
+    )
+    parser.add_argument(
+        "--use-dynamo",
+        action="store_true",
+        help="Use torch.onnx dynamo exporter (requires onnxscript).",
+    )
+    return parser.parse_args()
+
+
+def _load_cutie(args: argparse.Namespace) -> CUTIE:
+    config_dir = (Path(__file__).resolve().parents[1] / "cutie" / "config").as_posix()
+    overrides = [f"model={args.model}"]
+    if args.disable_object_transformer:
+        overrides.append("model.object_transformer.num_blocks=0")
+    with initialize_config_dir(version_base="1.3.2", config_dir=config_dir, job_name="onnx_export"):
+        cfg = compose(config_name="eval_config", overrides=overrides)
+    model = CUTIE(cfg)
+    checkpoint = torch.load(args.weights, map_location="cpu")
+    model.load_weights(_extract_state_dict(checkpoint))
+    return model
+
+
+def main() -> None:
+    args = parse_args()
+    if importlib.util.find_spec("onnx") is None:
+        raise ModuleNotFoundError(
+            "Missing dependency: onnx. Install it first (e.g. `pip install onnx`) to export."
+        )
+    if not args.weights.exists():
+        raise FileNotFoundError(f"Weights not found: {args.weights}")
+    if args.height <= 0 or args.width <= 0 or args.batch <= 0:
+        raise ValueError("height/width/batch must be positive integers.")
+    if args.num_objects <= 0 or args.memory_frames <= 0:
+        raise ValueError("num-objects/memory-frames must be positive integers.")
+    if args.device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but is not available.")
+    if args.use_dynamo and args.opset < 18:
+        print(f"--use-dynamo requested with opset {args.opset}; overriding to opset 18.")
+        args.opset = 18
+
+    device = torch.device(args.device)
+    model = _load_cutie(args).to(device).eval()
+    read_decode = CutieReadDecodeForOnnx(model).to(device).eval()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    write_path = args.output_dir / "cutie_memory_write.onnx"
+    read_decode_path = args.output_dir / "cutie_read_decode.onnx"
+
+    b = args.batch
+    n = args.num_objects
+    t = args.memory_frames
+    q = model.cfg.model.object_transformer.num_queries
+    e_plus_1 = model.cfg.model.embed_dim + 1
+    h = args.height
+    w = args.width
+
+    with torch.no_grad():
+        dummy_image = torch.randn(b, 3, h, w, device=device)
+        ms_features, pix_feat = model.encode_image(dummy_image)
+        key, _, selection = model.transform_key(ms_features[0])
+
+    h16, w16 = ms_features[0].shape[-2:]
+    memory_write = CutieMemoryWriteForOnnx(model, h16, w16).to(device).eval()
+    sensory_dim = model.cfg.model.sensory_dim
+    value_dim = model.cfg.model.value_dim
+    key_dim = model.cfg.model.key_dim
+
+    sensory = torch.randn(b, n, sensory_dim, h16, w16, device=device)
+    masks = torch.sigmoid(torch.randn(b, n, h, w, device=device))
+
+    memory_write_kwargs = dict(
+        model=memory_write,
+        args=(dummy_image, pix_feat, sensory, masks),
+        f=str(write_path),
+        export_params=True,
+        opset_version=args.opset,
+        do_constant_folding=True,
+        input_names=["image", "pix_feat", "sensory", "masks"],
+        output_names=["memory_mask_value", "new_sensory", "object_memory"],
+        dynamo=args.use_dynamo,
+    )
+    if not args.use_dynamo:
+        memory_write_kwargs["dynamic_axes"] = {
+            # NOTE: spatial dims are intentionally static for memory_write.
+            # ObjectSummarizer uses adaptive pooling with output size inferred from tensors;
+            # legacy ONNX export cannot represent that with dynamic output size.
+            "image": {0: "batch"},
+            "pix_feat": {0: "batch"},
+            "sensory": {0: "batch", 1: "num_objects"},
+            "masks": {0: "batch", 1: "num_objects"},
+            "memory_mask_value": {
+                0: "batch",
+                1: "num_objects",
+            },
+            "new_sensory": {
+                0: "batch",
+                1: "num_objects",
+            },
+            "object_memory": {0: "batch", 1: "num_objects"},
+        }
+    torch.onnx.export(**memory_write_kwargs)
+    _toposort_onnx_graph(write_path)
+
+    memory_key = torch.randn(b, key_dim, t, h16, w16, device=device)
+    memory_shrinkage = torch.abs(torch.randn(b, 1, t, h16, w16, device=device)) + 1.0
+    memory_mask_value = torch.randn(b, n, value_dim, t, h16, w16, device=device)
+    object_memory = torch.randn(b, n, t, q, e_plus_1, device=device)
+    last_mask = torch.sigmoid(torch.randn(b, n, h16, w16, device=device))
+    selector = torch.ones(b, n, 1, 1, device=device)
+
+    if not args.skip_read_decode:
+        read_decode_inputs = (
+            ms_features[0],
+            ms_features[1],
+            ms_features[2],
+            pix_feat,
+            key,
+            selection,
+            memory_key,
+            memory_shrinkage,
+            memory_mask_value,
+            object_memory,
+            sensory,
+            last_mask,
+            selector,
+        )
+        read_decode_kwargs = dict(
+            model=read_decode,
+            args=read_decode_inputs,
+            f=str(read_decode_path),
+            dynamo=args.use_dynamo,
+            export_params=True,
+            opset_version=args.opset,
+            do_constant_folding=True,
+            input_names=[
+                "ms_feat_16x",
+                "ms_feat_8x",
+                "ms_feat_4x",
+                "pix_feat",
+                "key",
+                "selection",
+                "memory_key",
+                "memory_shrinkage",
+                "memory_mask_value",
+                "object_memory",
+                "sensory",
+                "last_mask",
+                "selector",
+            ],
+            output_names=["memory_readout", "new_sensory", "logits", "prob"],
+        )
+        if not args.use_dynamo:
+            read_decode_kwargs["dynamic_axes"] = {
+                # NOTE: spatial dims are static for read_decode for exporter compatibility.
+                "ms_feat_16x": {0: "batch"},
+                "ms_feat_8x": {0: "batch"},
+                "ms_feat_4x": {0: "batch"},
+                "pix_feat": {0: "batch"},
+                "key": {0: "batch"},
+                "selection": {0: "batch"},
+                "memory_key": {0: "batch", 2: "memory_frames"},
+                "memory_shrinkage": {0: "batch", 2: "memory_frames"},
+                "memory_mask_value": {0: "batch", 1: "num_objects", 3: "memory_frames"},
+                "object_memory": {0: "batch", 1: "num_objects", 2: "memory_frames"},
+                "sensory": {0: "batch", 1: "num_objects"},
+                "last_mask": {0: "batch", 1: "num_objects"},
+                "selector": {0: "batch", 1: "num_objects"},
+                "memory_readout": {0: "batch", 1: "num_objects"},
+                "new_sensory": {0: "batch", 1: "num_objects"},
+                "logits": {0: "batch"},
+                "prob": {0: "batch"},
+            }
+        torch.onnx.export(**read_decode_kwargs)
+        _toposort_onnx_graph(read_decode_path)
+
+    print(f"Exported ONNX to: {write_path}")
+    if args.skip_read_decode:
+        print("Skipped read_decode export.")
+    else:
+        print(f"Exported ONNX to: {read_decode_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_ritm_onnx.py
+++ b/scripts/export_ritm_onnx.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+from gui.ritm.inference import utils as ritm_utils
+import gui.ritm.model.is_hrnet_model  # noqa: F401 - required for config class resolution
+
+
+class RITMNoBRSForOnnx(torch.nn.Module):
+    def __init__(self, model: torch.nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, image: torch.Tensor, coord_features: torch.Tensor) -> torch.Tensor:
+        # image: Bx4xHxW (RGB + prev mask)
+        # coord_features: Bx2xHxW (pos/neg click maps)
+        rgb, prev_mask = self.model.prepare_input(image)
+        if prev_mask is not None:
+            coord_features = torch.cat((prev_mask, coord_features), dim=1)
+
+        if self.model.rgb_conv is not None:
+            x = self.model.rgb_conv(torch.cat((rgb, coord_features), dim=1))
+            outputs = self.model.backbone_forward(x)
+        else:
+            coord_features = self.model.maps_transform(coord_features)
+            outputs = self.model.backbone_forward(rgb, coord_features)
+        return F.interpolate(
+            outputs["instances"],
+            size=rgb.size()[2:],
+            mode="bilinear",
+            align_corners=True,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Export RITM click model (NoBRS forward) to ONNX."
+    )
+    p.add_argument(
+        "--weights",
+        type=Path,
+        default=Path("weights/coco_lvis_h18_itermask.pth"),
+        help="RITM checkpoint path.",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=Path("weights/ritm_no_brs.onnx"),
+        help="Output ONNX path.",
+    )
+    p.add_argument("--height", type=int, default=480)
+    p.add_argument("--width", type=int, default=864)
+    p.add_argument("--opset", type=int, default=17)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.weights.exists():
+        raise FileNotFoundError(f"Weights not found: {args.weights}")
+    # Use torch-based distance maps for ONNX exportability (cpu_dist_maps=True uses numpy/cython path).
+    model = ritm_utils.load_is_model(str(args.weights), device="cpu", cpu_dist_maps=False).eval()
+    wrapper = RITMNoBRSForOnnx(model).eval()
+
+    # with_prev_mask=True for the shipped checkpoint; image has 4 channels (RGB + prev mask).
+    image = torch.randn(1, 4, args.height, args.width)
+    coord_features = torch.zeros(1, 2, args.height, args.width, dtype=torch.float32)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    torch.onnx.export(
+        wrapper,
+        (image, coord_features),
+        str(args.output),
+        dynamo=False,
+        export_params=True,
+        opset_version=args.opset,
+        do_constant_folding=True,
+        input_names=["image", "coord_features"],
+        output_names=["instances"],
+        dynamic_axes={
+            "image": {2: "height", 3: "width"},
+            "coord_features": {2: "height", 3: "width"},
+            "instances": {2: "height", 3: "width"},
+        },
+    )
+
+    # Validate exported graph still exposes click points as an input.
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(str(args.output), providers=["CPUExecutionProvider"])
+    inputs = [x.name for x in sess.get_inputs()]
+    if "coord_features" not in inputs:
+        raise RuntimeError(
+            f"Exported model {args.output} does not include 'coord_features' input (inputs: {inputs}). "
+            "The graph is not usable for interactive clicks."
+        )
+    print(f"Exported ONNX to: {args.output}")
+
+
+if __name__ == "__main__":
+    main()
+import torch.nn.functional as F

--- a/scripts/onnx_verifier.py
+++ b/scripts/onnx_verifier.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+import argparse
+import importlib.util
+from pathlib import Path
+import time
+from typing import Sequence
+
+import numpy as np
+import onnx
+import torch
+from hydra import compose, initialize_config_dir
+from onnx import checker, shape_inference
+from onnx.reference import ReferenceEvaluator
+
+from cutie.model.cutie import CUTIE
+from scripts.export_onnx import CutieImageEncoderForOnnx, _extract_state_dict
+
+OUTPUT_NAMES: Sequence[str] = (
+    "ms_feat_16x",
+    "ms_feat_8x",
+    "ms_feat_4x",
+    "pix_feat",
+    "key",
+    "shrinkage",
+    "selection",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate CUTIE ONNX (model check + inference parity vs PyTorch)."
+    )
+    parser.add_argument("--onnx", type=Path, required=True, help="Path to ONNX model file.")
+    parser.add_argument(
+        "--weights",
+        type=Path,
+        default=Path("weights/cutie-base-mega.pth"),
+        help="Checkpoint path for CUTIE weights.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="base",
+        choices=["base", "small"],
+        help="CUTIE model config variant.",
+    )
+    parser.add_argument("--height", type=int, default=128, help="Validation input height.")
+    parser.add_argument("--width", type=int, default=128, help="Validation input width.")
+    parser.add_argument("--batch", type=int, default=1, help="Validation input batch size.")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed.")
+    parser.add_argument("--rtol", type=float, default=1e-4, help="allclose rtol.")
+    parser.add_argument("--atol", type=float, default=1e-4, help="allclose atol.")
+    return parser.parse_args()
+
+
+def _load_pytorch_wrapper(model_name: str, weights_path: Path) -> CutieImageEncoderForOnnx:
+    config_dir = (Path(__file__).resolve().parents[1] / "cutie" / "config").as_posix()
+    with initialize_config_dir(version_base="1.3.2", config_dir=config_dir, job_name="onnx_verify"):
+        cfg = compose(config_name="eval_config", overrides=[f"model={model_name}"])
+    model = CUTIE(cfg)
+    checkpoint = torch.load(weights_path, map_location="cpu")
+    model.load_weights(_extract_state_dict(checkpoint))
+    return CutieImageEncoderForOnnx(model).eval()
+
+
+def _run_onnx(model: onnx.ModelProto, image: np.ndarray):
+    if importlib.util.find_spec("onnxruntime") is not None:
+        import onnxruntime as ort  # type: ignore
+
+        sess = ort.InferenceSession(model.SerializeToString(), providers=["CPUExecutionProvider"])
+        return sess.run(None, {"image": image}), "onnxruntime"
+    return ReferenceEvaluator(model).run(None, {"image": image}), "onnx.reference"
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.onnx.exists():
+        raise FileNotFoundError(f"ONNX file not found: {args.onnx}")
+    if not args.weights.exists():
+        raise FileNotFoundError(f"Weights file not found: {args.weights}")
+    if args.height <= 0 or args.width <= 0 or args.batch <= 0:
+        raise ValueError("height/width/batch must be positive integers.")
+
+    onnx_model = onnx.load(str(args.onnx))
+    checker.check_model(onnx_model)
+    inferred = shape_inference.infer_shapes(onnx_model)
+    print("ONNX checker: PASS")
+    print("ONNX outputs:", [o.name for o in inferred.graph.output])
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    input_tensor = torch.randn(args.batch, 3, args.height, args.width, dtype=torch.float32)
+
+    start = time.time()
+    wrapper = _load_pytorch_wrapper(args.model, args.weights)
+    with torch.no_grad():
+        torch_out = wrapper(input_tensor)
+        print("PyTorch inference time:", time.time() - start, "seconds")
+
+    start = time.time()
+    onnx_out, engine = _run_onnx(onnx_model, input_tensor.numpy())
+    print("ONNX inference time:", time.time() - start, "seconds")
+    print(f"ONNX runtime engine: {engine}")
+
+    all_ok = True
+    for i, name in enumerate(OUTPUT_NAMES):
+        pt = torch_out[i].detach().cpu().numpy()
+        ox = onnx_out[i]
+        ok = np.allclose(pt, ox, rtol=args.rtol, atol=args.atol)
+        max_abs = float(np.max(np.abs(pt - ox)))
+        mean_abs = float(np.mean(np.abs(pt - ox)))
+        print(
+            f"{name}: shape={pt.shape}, allclose={ok}, "
+            f"max_abs={max_abs:.6e}, mean_abs={mean_abs:.6e}"
+        )
+        all_ok = all_ok and ok
+
+    if not all_ok:
+        raise RuntimeError("ONNX parity check failed.")
+    print("Numerical check: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_onnx/memory_write.py
+++ b/scripts/verify_onnx/memory_write.py
@@ -1,0 +1,100 @@
+"""
+Verify CUTIE memory_write ONNX graph against PyTorch.
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+import onnx
+import onnxruntime as ort
+from onnx import checker
+
+from scripts.export_onnx_pipeline import (
+    CutieMemoryWriteForOnnx,
+    _load_cutie,
+)
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--onnx", type=Path, required=True)
+    p.add_argument("--weights", type=str, required=True)
+    p.add_argument("--model", type=str, default="base")
+    p.add_argument("--height", type=int, default=128)
+    p.add_argument("--width", type=int, default=128)
+    p.add_argument("--objects", type=int, default=2)
+    p.add_argument("--rtol", type=float, default=1e-3)
+    p.add_argument("--atol", type=float, default=1e-3)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Load ONNX
+    onnx_model = onnx.load(str(args.onnx))
+    checker.check_model(onnx_model)
+    print("ONNX checker: PASS")
+
+    session = ort.InferenceSession(
+        str(args.onnx),
+        providers=["CPUExecutionProvider"],
+    )
+
+    # Load CUTIE
+    class Args:
+        model = args.model
+        weights = args.weights
+        disable_object_transformer = False
+
+    model = _load_cutie(Args()).eval()
+
+    b = 1
+    n = args.objects
+    h, w = args.height, args.width
+
+    with torch.no_grad():
+        image = torch.randn(b, 3, h, w)
+        ms, pix = model.encode_image(image)
+
+        h16, w16 = ms[0].shape[-2:]
+
+        sensory = torch.randn(
+            b, n, model.cfg.model.sensory_dim, h16, w16
+        )
+        masks = torch.sigmoid(torch.randn(b, n, h, w))
+
+        wrapper = CutieMemoryWriteForOnnx(model, h16, w16).eval()
+        pt_out = wrapper(image, pix, sensory, masks)
+
+    ort_out = session.run(
+        None,
+        {
+            "image": image.numpy(),
+            "pix_feat": pix.numpy(),
+            "sensory": sensory.numpy(),
+            "masks": masks.numpy(),
+        },
+    )
+
+    names = ["memory_mask_value", "new_sensory", "object_memory"]
+
+    all_ok = True
+    for i, name in enumerate(names):
+        a = pt_out[i].numpy()
+        b_ = ort_out[i]
+        ok = np.allclose(a, b_, rtol=args.rtol, atol=args.atol)
+        max_diff = float(np.max(np.abs(a - b_)))
+        print(f"{name}: allclose={ok}, max_diff={max_diff:.6e}")
+        all_ok &= ok
+
+    if not all_ok:
+        raise RuntimeError("Numerical mismatch detected.")
+
+    print("memory_write parity: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_onnx/read_decode.py
+++ b/scripts/verify_onnx/read_decode.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Verify CUTIE read_decode ONNX graph against PyTorch.
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+import onnx
+import onnxruntime as ort
+from onnx import checker
+
+from scripts.export_onnx_pipeline import (
+    CutieReadDecodeForOnnx,
+    _load_cutie,
+)
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--onnx", type=Path, required=True)
+    p.add_argument("--weights", type=str, required=True)
+    p.add_argument("--model", type=str, default="base")
+    p.add_argument("--height", type=int, default=128)
+    p.add_argument("--width", type=int, default=128)
+    p.add_argument("--objects", type=int, default=2)
+    p.add_argument("--memory_len", type=int, default=2)
+    p.add_argument("--rtol", type=float, default=1e-3)
+    p.add_argument("--atol", type=float, default=1e-3)
+    p.add_argument(
+        "--strict-logits",
+        action="store_true",
+        help="Fail on logits mismatch as well. By default, parity requires memory_readout/new_sensory/prob only.",
+    )
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    onnx_model = onnx.load(str(args.onnx))
+    checker.check_model(onnx_model)
+    print("ONNX checker: PASS")
+
+    session = ort.InferenceSession(
+        str(args.onnx),
+        providers=["CPUExecutionProvider"],
+    )
+
+    class Args:
+        model = args.model
+        weights = args.weights
+        disable_object_transformer = False
+
+    model = _load_cutie(Args()).eval()
+
+    b = 1
+    n = args.objects
+    t = args.memory_len
+    h, w = args.height, args.width
+
+    with torch.no_grad():
+        image = torch.randn(b, 3, h, w)
+        ms, pix = model.encode_image(image)
+        key, _, selection = model.transform_key(ms[0])
+
+        h16, w16 = ms[0].shape[-2:]
+
+        sensory = torch.randn(b, n, model.cfg.model.sensory_dim, h16, w16)
+        memory_key = torch.randn(b, model.cfg.model.key_dim, t, h16, w16)
+        memory_shrinkage = torch.abs(
+            torch.randn(b, 1, t, h16, w16)
+        ) + 1.0
+        memory_mask_value = torch.randn(
+            b, n, model.cfg.model.value_dim, t, h16, w16
+        )
+        object_memory = torch.randn(
+            b,
+            n,
+            t,
+            model.cfg.model.object_transformer.num_queries,
+            model.cfg.model.embed_dim + 1,
+        )
+        last_mask = torch.sigmoid(torch.randn(b, n, h16, w16))
+        selector = torch.ones(b, n, 1, 1)
+
+        wrapper = CutieReadDecodeForOnnx(model).eval()
+        pt_out = wrapper(
+            ms[0],
+            ms[1],
+            ms[2],
+            pix,
+            key,
+            selection,
+            memory_key,
+            memory_shrinkage,
+            memory_mask_value,
+            object_memory,
+            sensory,
+            last_mask,
+            selector,
+        )
+
+    ort_out = session.run(
+        None,
+        {
+            "ms_feat_16x": ms[0].numpy(),
+            "ms_feat_8x": ms[1].numpy(),
+            "ms_feat_4x": ms[2].numpy(),
+            "pix_feat": pix.numpy(),
+            "key": key.numpy(),
+            "selection": selection.numpy(),
+            "memory_key": memory_key.numpy(),
+            "memory_shrinkage": memory_shrinkage.numpy(),
+            "memory_mask_value": memory_mask_value.numpy(),
+            "object_memory": object_memory.numpy(),
+            "sensory": sensory.numpy(),
+            "last_mask": last_mask.numpy(),
+            "selector": selector.numpy(),
+        },
+    )
+
+    names = ["memory_readout", "new_sensory", "logits", "prob"]
+    required = {"memory_readout", "new_sensory", "prob"}
+    if args.strict_logits:
+        required.add("logits")
+
+    all_ok = True
+    for i, name in enumerate(names):
+        a = pt_out[i].numpy()
+        b_ = ort_out[i]
+        ok = np.allclose(a, b_, rtol=args.rtol, atol=args.atol)
+        max_diff = float(np.max(np.abs(a - b_)))
+        marker = "required" if name in required else "optional"
+        print(f"{name} ({marker}): allclose={ok}, max_diff={max_diff:.6e}")
+        if name in required:
+            all_ok &= ok
+
+    if not all_ok:
+        raise RuntimeError("Numerical mismatch detected in required outputs.")
+
+    print("read_decode parity: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
frames for rgba mode were transparent and hence in `.png` format which it wasn't detecting.
`.mp4` format doesn't support transparency. Exporting video with green overlay as shown in GUI can be helpful for any processing like background removal in video editors.
Other option is exporting `.mov` file (which supports transparency) but that creates large file sizes.

fixes #146 